### PR TITLE
feat(tests): add pytest test suite for all operations

### DIFF
--- a/Docs/implementation-plan.md
+++ b/Docs/implementation-plan.md
@@ -1,200 +1,65 @@
 # gl-settings CLI Extension Plan
 
-## Context
+## Current Status
 
-The gl-settings CLI tool applies settings to GitLab groups/projects with recursive traversal. It has two working operations (`protect-branch`, `protect-tag`) and needs to be extended into a production-ready tool with additional operations, error resilience, filtering, and proper packaging.
+**Last Updated:** During session - PR #13 open for issue #6
+
+### Completed Issues
+| Issue | Title | PR | Status |
+|-------|-------|-----|--------|
+| #1 | Retry logic with exponential backoff | #8 | ✅ Merged |
+| #2 | --filter flag for project filtering | #9 | ✅ Merged |
+| #3 | project-setting operation | #10 | ✅ Merged |
+| #4 | approval-rule operation | #11 | ✅ Merged |
+| #5 | merge-request-setting operation | #12 | ✅ Merged |
+
+### In Progress
+| Issue | Title | PR | Status |
+|-------|-------|-----|--------|
+| #6 | pytest test suite | #13 | 🔄 PR Open - ready to merge |
+
+### Remaining Issues
+| Issue | Title | Blocked By | Status |
+|-------|-------|------------|--------|
+| #7 | Packaging + CI (pyproject.toml, Makefile, GitHub Actions) | #6 | ⏳ Blocked |
+
+---
 
 ## Implementation Order
 
-| Phase | Feature | Rationale |
-|-------|---------|-----------|
-| 1 | Retry Logic | Foundation - all features benefit from resilient API calls |
-| 2 | `--filter` Flag | Enables safer testing against large groups |
-| 3 | `project-setting` Operation | Most generally useful, establishes group-level pattern |
-| 4 | `approval-rule` Operation | Builds on phase 3 patterns |
-| 5 | `merge-request-setting` Operation | Most complex (dual-API support) |
-| 6 | Test Suite | Validates all features |
-| 7 | Packaging | Finalization |
+| Phase | Feature | Status |
+|-------|---------|--------|
+| 1 | Retry Logic | ✅ Done |
+| 2 | `--filter` Flag | ✅ Done |
+| 3 | `project-setting` Operation | ✅ Done |
+| 4 | `approval-rule` Operation | ✅ Done |
+| 5 | `merge-request-setting` Operation | ✅ Done |
+| 6 | Test Suite | 🔄 PR Open |
+| 7 | Packaging + CI | ⏳ Next |
 
 ---
 
-## Phase 1: Retry Logic
+## Key Files
 
-**File:** `gl_settings.py`
+- `gl_settings.py` - Main CLI (~1100 lines now with all operations)
+- `CLAUDE.md` - Project rules and conventions
+- `Docs/implementation-plan.md` - This file
 
-**Changes:**
-1. Add `import time` and constants:
-   ```python
-   DEFAULT_MAX_RETRIES = 3
-   RETRY_BACKOFF_FACTOR = 0.5
-   RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
-   ```
+## Operations Implemented
 
-2. Update `GitLabClient.__init__` to accept `max_retries` parameter
+1. **protect-branch** - Branch protection (original)
+2. **protect-tag** - Tag protection (original)
+3. **project-setting** - Generic key=value settings for projects/groups
+4. **approval-rule** - MR approval rules CRUD
+5. **merge-request-setting** - MR approval settings (dual-API)
 
-3. Replace `_request()` method (lines 159-166) with retry loop:
-   - Retry on 429 and 5xx responses
-   - Use `Retry-After` header for 429s
-   - Exponential backoff: `RETRY_BACKOFF_FACTOR * (2 ** attempt)`
-   - Also retry on `ConnectionError`
+## Next Steps
 
-4. Add `--max-retries` global flag in `build_parser()` (line ~614)
+1. Merge PR #13 (test suite)
+2. Start #7 (packaging + CI) - pyproject.toml, Makefile, GitHub Actions
 
----
+## Session Notes
 
-## Phase 2: `--filter` Flag
-
-**File:** `gl_settings.py`
-
-**Changes:**
-1. Add `import fnmatch`
-
-2. Add global flag in `build_parser()`:
-   ```python
-   parser.add_argument("--filter", dest="filter_pattern", default=None,
-                       help="Glob pattern to filter projects by path_with_namespace")
-   ```
-
-3. Update `recurse()` signature to accept `filter_pattern: str | None = None`
-
-4. Add filter checks before `apply_to_project()` calls:
-   ```python
-   if filter_pattern and not fnmatch.fnmatch(project_path, filter_pattern):
-       logger.debug(f"Skipping project (filter): {project_path}")
-       continue
-   ```
-
-5. Update `main()` to pass `filter_pattern=args.filter_pattern` to `recurse()`
-
----
-
-## Phase 3: `project-setting` Operation
-
-**File:** `gl_settings.py` (after `ProtectTagOperation`, line ~593)
-
-**Design:**
-- `--setting key=value` (repeatable via `action="append"`)
-- Split on first `=` to allow values containing `=`
-- Type coercion: `true/false` → bool, numeric strings → int/float
-- Works on both projects (`PUT /projects/:id`) and groups (`PUT /groups/:id`)
-- Idempotency: GET current settings, compare each key, only PUT if changed
-
-**Implementation:**
-```python
-@register_operation("project-setting")
-class ProjectSettingOperation(Operation):
-    def applies_to_group(self) -> bool:
-        return True
-
-    def _apply_settings(self, entity_type, entity_id, entity_path, get_endpoint, put_endpoint):
-        # Parse settings, GET current, compare, PUT if changed
-```
-
----
-
-## Phase 4: `approval-rule` Operation
-
-**File:** `gl_settings.py`
-
-**Design:**
-- `--rule-name` (required) - identifies rule
-- `--approvals` (int) - required approvals count
-- `--add-user` / `--remove-user` (repeatable) - accepts usernames or IDs
-- `--unprotect` - delete the rule
-- API: `GET/POST/PUT/DELETE /projects/:id/approval_rules`
-
-**Additional client method:**
-```python
-def resolve_user(self, identifier: str) -> int:
-    """Resolve username or ID to numeric user ID via GET /users?username="""
-```
-
-**Idempotency:** Find rule by name, compare approvals count and user list
-
----
-
-## Phase 5: `merge-request-setting` Operation
-
-**File:** `gl_settings.py`
-
-**Design:**
-- `--approvals-before-merge`, `--reset-approvals-on-push`, `--disable-overriding-approvers`
-- Dual-API support for GitLab version compatibility:
-  1. Try modern API: `PUT /projects/:id/merge_request_approval_settings`
-  2. Fall back to legacy: `POST /projects/:id/approvals`
-- Log which API was used at debug level
-
----
-
-## Phase 6: Test Suite
-
-**New files:**
-```
-tests/
-├── __init__.py
-├── conftest.py          # Shared fixtures: mock_client, sample_project, sample_group
-├── test_url_parsing.py  # Unit tests for _extract_path_from_url()
-├── test_idempotency.py  # Unit tests for already_set detection
-├── test_operations.py   # Integration tests with responses library
-└── test_dry_run.py      # Verify no POST/PUT/DELETE in dry-run
-```
-
-**Key test cases:**
-- URL parsing: full URLs, bare paths, `.git` suffix, `/-/` paths
-- Idempotency: same settings → `already_set`, different → `applied`
-- Recursion: nested groups, filter pattern matching
-- Dry-run: only GET calls, no mutations
-
----
-
-## Phase 7: Packaging
-
-**New files:**
-
-**`pyproject.toml`:**
-- `requests>=2.28.0` dependency
-- `pytest`, `responses`, `ruff`, `mypy` dev dependencies
-- Entry point: `gl-settings = gl_settings:main`
-- Python >= 3.10
-
-**`Makefile`:**
-```makefile
-install:      pip install .
-install-dev:  pip install -e ".[dev]"
-lint:         ruff check
-test:         pytest tests/ -v
-```
-
----
-
-## Files to Modify/Create
-
-| File | Action |
-|------|--------|
-| `gl_settings.py` | Modify - add retry, filter, 3 new operations |
-| `pyproject.toml` | Create - packaging config |
-| `Makefile` | Create - build targets |
-| `tests/conftest.py` | Create - shared fixtures |
-| `tests/test_url_parsing.py` | Create |
-| `tests/test_idempotency.py` | Create |
-| `tests/test_operations.py` | Create |
-| `tests/test_dry_run.py` | Create |
-
----
-
-## Verification
-
-After implementation:
-1. `make install-dev` - install with dev deps
-2. `make test` - run test suite
-3. `make lint` - check code style
-4. Manual tests:
-   ```bash
-   # Dry-run project-setting
-   python gl_settings.py --dry-run project-setting https://gitlab.com/myorg \
-       --setting visibility=private --setting merge_method=ff
-
-   # Filter test
-   python gl_settings.py --dry-run --filter "myorg/team-*" protect-branch \
-       https://gitlab.com/myorg --branch main --push maintainer --merge developer
-   ```
+- All operations follow the same pattern: `@register_operation`, `add_arguments()`, `apply_to_project()`
+- Idempotency is key: GET current state, compare, only mutate if different
+- `--dry-run` and `--filter` work with all operations via the recursion engine

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for gl-settings CLI tool."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,120 @@
+"""Shared test fixtures for gl-settings tests."""
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+import responses
+
+# Add parent directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from gl_settings import GitLabClient, Target, TargetType
+
+# Constants for use in tests - pytest makes conftest.py fixtures available,
+# but these constants need to be imported directly from tests
+MOCK_GITLAB_URL = "https://gitlab.example.com"
+MOCK_API_URL = f"{MOCK_GITLAB_URL}/api/v4"
+
+@pytest.fixture
+def mock_client():
+    """GitLabClient pointing at mock server."""
+    return GitLabClient(MOCK_GITLAB_URL, "test-token", dry_run=False)
+
+
+@pytest.fixture
+def dry_run_client():
+    """GitLabClient in dry-run mode."""
+    return GitLabClient(MOCK_GITLAB_URL, "test-token", dry_run=True)
+
+
+@pytest.fixture
+def sample_project() -> dict[str, Any]:
+    """Sample project API response."""
+    return {
+        "id": 123,
+        "name": "my-project",
+        "path_with_namespace": "myorg/my-project",
+        "web_url": f"{MOCK_GITLAB_URL}/myorg/my-project",
+    }
+
+
+@pytest.fixture
+def sample_group() -> dict[str, Any]:
+    """Sample group API response."""
+    return {
+        "id": 456,
+        "name": "myorg",
+        "full_path": "myorg",
+        "web_url": f"{MOCK_GITLAB_URL}/myorg",
+    }
+
+
+@pytest.fixture
+def nested_group_structure() -> dict[str, Any]:
+    """Nested groups with projects for recursion tests."""
+    return {
+        "root": {"id": 1, "name": "org", "full_path": "org", "web_url": f"{MOCK_GITLAB_URL}/org"},
+        "subgroups": [
+            {
+                "id": 2,
+                "name": "team-a",
+                "full_path": "org/team-a",
+                "web_url": f"{MOCK_GITLAB_URL}/org/team-a",
+            },
+            {
+                "id": 3,
+                "name": "team-b",
+                "full_path": "org/team-b",
+                "web_url": f"{MOCK_GITLAB_URL}/org/team-b",
+            },
+        ],
+        "root_projects": [
+            {"id": 10, "path_with_namespace": "org/shared"},
+        ],
+        "team_a_projects": [
+            {"id": 11, "path_with_namespace": "org/team-a/service"},
+            {"id": 12, "path_with_namespace": "org/team-a/frontend"},
+        ],
+        "team_b_projects": [],
+    }
+
+
+@pytest.fixture
+def sample_target_project(sample_project) -> Target:
+    """Sample Target object for a project."""
+    return Target(
+        type=TargetType.PROJECT,
+        id=sample_project["id"],
+        path=sample_project["path_with_namespace"],
+        name=sample_project["name"],
+        web_url=sample_project["web_url"],
+    )
+
+
+@pytest.fixture
+def sample_target_group(sample_group) -> Target:
+    """Sample Target object for a group."""
+    return Target(
+        type=TargetType.GROUP,
+        id=sample_group["id"],
+        path=sample_group["full_path"],
+        name=sample_group["name"],
+        web_url=sample_group["web_url"],
+    )
+
+
+def make_args(**kwargs) -> argparse.Namespace:
+    """Helper to create argparse.Namespace with default values."""
+    defaults = {
+        "dry_run": False,
+        "json_output": False,
+        "verbose": False,
+        "gitlab_url": None,
+        "max_retries": 3,
+        "filter_pattern": None,
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1,0 +1,304 @@
+"""Safety tests for dry-run mode - ensures no mutations occur."""
+
+import argparse
+import sys
+from pathlib import Path
+
+import pytest
+import responses
+
+# Add parent directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# Constants
+MOCK_GITLAB_URL = "https://gitlab.example.com"
+MOCK_API_URL = f"{MOCK_GITLAB_URL}/api/v4"
+
+
+def make_args(**kwargs) -> argparse.Namespace:
+    """Helper to create argparse.Namespace with default values."""
+    defaults = {
+        "dry_run": False,
+        "json_output": False,
+        "verbose": False,
+        "gitlab_url": None,
+        "max_retries": 3,
+        "filter_pattern": None,
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+from gl_settings import (
+    GitLabClient,
+    ProtectBranchOperation,
+    ProtectTagOperation,
+    ProjectSettingOperation,
+    ApprovalRuleOperation,
+    MergeRequestSettingOperation,
+)
+
+
+class TestDryRunProtectBranch:
+    """Dry-run tests for protect-branch operation."""
+
+    @responses.activate
+    def test_dry_run_no_post_when_creating(self):
+        """Dry-run should not POST when branch is unprotected."""
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123/protected_branches/main",
+            status=404,
+        )
+        # NO POST registered - test fails if POST is attempted
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", dry_run=True)
+        args = make_args(branch="main", push="maintainer", merge="developer", unprotect=False, allow_force_push=False)
+        op = ProtectBranchOperation(client, args)
+        result = op.apply_to_project(123, "myorg/myproject")
+
+        assert result.action == "would_apply"
+        assert result.dry_run is True
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.method == "GET"
+
+    @responses.activate
+    def test_dry_run_no_delete_when_updating(self):
+        """Dry-run should not DELETE/POST when updating branch protection."""
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123/protected_branches/main",
+            json={
+                "name": "main",
+                "push_access_levels": [{"access_level": 30}],  # developer (different)
+                "merge_access_levels": [{"access_level": 30}],
+                "allow_force_push": False,
+            },
+        )
+        # NO DELETE or POST registered - test fails if they're attempted
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", dry_run=True)
+        args = make_args(branch="main", push="maintainer", merge="developer", unprotect=False, allow_force_push=False)
+        op = ProtectBranchOperation(client, args)
+        result = op.apply_to_project(123, "myorg/myproject")
+
+        assert result.action == "would_apply"
+        assert result.dry_run is True
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.method == "GET"
+
+
+class TestDryRunProtectTag:
+    """Dry-run tests for protect-tag operation."""
+
+    @responses.activate
+    def test_dry_run_no_post_when_creating(self):
+        """Dry-run should not POST when tag is unprotected."""
+        # Note: * is URL-encoded to %2A
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123/protected_tags/v1.0.%2A",
+            status=404,
+        )
+        # NO POST registered
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", dry_run=True)
+        args = make_args(tag="v1.0.*", create="maintainer", unprotect=False)
+        op = ProtectTagOperation(client, args)
+        result = op.apply_to_project(123, "myorg/myproject")
+
+        assert result.action == "would_apply"
+        assert result.dry_run is True
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.method == "GET"
+
+
+class TestDryRunProjectSetting:
+    """Dry-run tests for project-setting operation."""
+
+    @responses.activate
+    def test_dry_run_no_put_when_changing(self):
+        """Dry-run should not PUT when settings differ."""
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123",
+            json={"id": 123, "visibility": "public"},
+        )
+        # NO PUT registered
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", dry_run=True)
+        args = make_args(settings=["visibility=private"])
+        op = ProjectSettingOperation(client, args)
+        result = op.apply_to_project(123, "myorg/myproject")
+
+        assert result.action == "would_apply"
+        assert result.dry_run is True
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.method == "GET"
+
+
+class TestDryRunApprovalRule:
+    """Dry-run tests for approval-rule operation."""
+
+    @responses.activate
+    def test_dry_run_no_post_when_creating_rule(self):
+        """Dry-run should not POST when creating new rule."""
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123/approval_rules",
+            json=[],  # No existing rules
+        )
+        # NO POST registered
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", dry_run=True)
+        args = make_args(
+            rule_name="Security Review",
+            approvals=2,
+            add_users=[],
+            remove_users=[],
+            unprotect=False,
+        )
+        op = ApprovalRuleOperation(client, args)
+        result = op.apply_to_project(123, "myorg/myproject")
+
+        assert result.action == "would_apply"
+        assert result.dry_run is True
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.method == "GET"
+
+    @responses.activate
+    def test_dry_run_no_delete_when_removing_rule(self):
+        """Dry-run should not DELETE when unprotecting."""
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123/approval_rules",
+            json=[{"id": 1, "name": "Security Review", "approvals_required": 2, "users": []}],
+        )
+        # NO DELETE registered
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", dry_run=True)
+        args = make_args(
+            rule_name="Security Review",
+            approvals=None,
+            add_users=[],
+            remove_users=[],
+            unprotect=True,
+        )
+        op = ApprovalRuleOperation(client, args)
+        result = op.apply_to_project(123, "myorg/myproject")
+
+        assert result.action == "would_apply"
+        assert result.dry_run is True
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.method == "GET"
+
+
+class TestDryRunMergeRequestSetting:
+    """Dry-run tests for merge-request-setting operation."""
+
+    @responses.activate
+    def test_dry_run_no_put_modern_api(self):
+        """Dry-run should not PUT on modern API."""
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123/merge_request_approval_settings",
+            json={
+                "retain_approvals_on_push": True,  # reset_approvals_on_push=false equivalent
+            },
+        )
+        # NO PUT registered
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", dry_run=True)
+        args = make_args(
+            approvals_before_merge=None,
+            reset_approvals_on_push="true",  # Wants to change to reset (retain=false)
+            disable_overriding_approvers=None,
+            merge_requests_author_approval=None,
+            merge_requests_disable_committers_approval=None,
+        )
+        op = MergeRequestSettingOperation(client, args)
+        result = op.apply_to_project(123, "myorg/myproject")
+
+        assert result.action == "would_apply"
+        assert result.dry_run is True
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.method == "GET"
+
+    @responses.activate
+    def test_dry_run_no_post_legacy_api(self):
+        """Dry-run should not POST on legacy API fallback."""
+        # Modern API returns 404
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123/merge_request_approval_settings",
+            status=404,
+        )
+        # Legacy API works
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123/approvals",
+            json={"approvals_before_merge": 1},
+        )
+        # NO POST registered
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", dry_run=True)
+        args = make_args(
+            approvals_before_merge=2,  # Different
+            reset_approvals_on_push=None,
+            disable_overriding_approvers=None,
+            merge_requests_author_approval=None,
+            merge_requests_disable_committers_approval=None,
+        )
+        op = MergeRequestSettingOperation(client, args)
+        result = op.apply_to_project(123, "myorg/myproject")
+
+        assert result.action == "would_apply"
+        assert result.dry_run is True
+        # Should have 2 GETs (modern 404, then legacy)
+        assert len(responses.calls) == 2
+        for call in responses.calls:
+            assert call.request.method == "GET"
+
+
+class TestDryRunOnlyGets:
+    """Verify dry-run mode never uses mutating methods."""
+
+    @responses.activate
+    def test_dry_run_only_uses_get_method(self):
+        """Comprehensive check that dry-run only uses GET."""
+        # Setup responses for various endpoints that might be called
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123/protected_branches/main",
+            status=404,
+        )
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123",
+            json={"id": 123, "visibility": "public"},
+        )
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123/approval_rules",
+            json=[],
+        )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", dry_run=True)
+
+        # Test protect-branch
+        args1 = make_args(branch="main", push="maintainer", merge="developer", unprotect=False, allow_force_push=False)
+        op1 = ProtectBranchOperation(client, args1)
+        op1.apply_to_project(123, "myorg/myproject")
+
+        # Test project-setting
+        args2 = make_args(settings=["visibility=private"])
+        op2 = ProjectSettingOperation(client, args2)
+        op2.apply_to_project(123, "myorg/myproject")
+
+        # Test approval-rule
+        args3 = make_args(rule_name="Test", approvals=1, add_users=[], remove_users=[], unprotect=False)
+        op3 = ApprovalRuleOperation(client, args3)
+        op3.apply_to_project(123, "myorg/myproject")
+
+        # Verify ALL calls were GET
+        for call in responses.calls:
+            assert call.request.method == "GET", f"Non-GET method used in dry-run: {call.request.method}"

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -1,0 +1,262 @@
+"""Unit tests for idempotency detection in operations."""
+
+import argparse
+import sys
+from pathlib import Path
+
+import pytest
+import responses
+
+# Add parent directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# Constants
+MOCK_GITLAB_URL = "https://gitlab.example.com"
+MOCK_API_URL = f"{MOCK_GITLAB_URL}/api/v4"
+
+
+def make_args(**kwargs) -> argparse.Namespace:
+    """Helper to create argparse.Namespace with default values."""
+    defaults = {
+        "dry_run": False,
+        "json_output": False,
+        "verbose": False,
+        "gitlab_url": None,
+        "max_retries": 3,
+        "filter_pattern": None,
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+from gl_settings import (
+    GitLabClient,
+    ProtectBranchOperation,
+    ProtectTagOperation,
+    ProjectSettingOperation,
+    ApprovalRuleOperation,
+)
+
+
+class TestProtectBranchIdempotency:
+    """Tests for protect-branch idempotency."""
+
+    @responses.activate
+    def test_already_protected_same_settings(self):
+        """Branch already protected with same settings returns already_set."""
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123/protected_branches/main",
+            json={
+                "name": "main",
+                "push_access_levels": [{"access_level": 40}],  # maintainer
+                "merge_access_levels": [{"access_level": 30}],  # developer
+                "allow_force_push": False,
+            },
+        )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token")
+        args = make_args(branch="main", push="maintainer", merge="developer", unprotect=False, allow_force_push=False)
+        op = ProtectBranchOperation(client, args)
+        result = op.apply_to_project(123, "myorg/myproject")
+
+        assert result.action == "already_set"
+        assert len(responses.calls) == 1  # Only GET, no DELETE/POST
+
+    @responses.activate
+    def test_different_settings_updates(self):
+        """Branch with different settings triggers update."""
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123/protected_branches/main",
+            json={
+                "name": "main",
+                "push_access_levels": [{"access_level": 30}],  # developer (different)
+                "merge_access_levels": [{"access_level": 30}],
+                "allow_force_push": False,
+            },
+        )
+        responses.add(
+            responses.DELETE,
+            f"{MOCK_API_URL}/projects/123/protected_branches/main",
+            status=204,
+        )
+        responses.add(
+            responses.POST,
+            f"{MOCK_API_URL}/projects/123/protected_branches",
+            json={"name": "main"},
+        )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token")
+        args = make_args(branch="main", push="maintainer", merge="developer", unprotect=False, allow_force_push=False)
+        op = ProtectBranchOperation(client, args)
+        result = op.apply_to_project(123, "myorg/myproject")
+
+        assert result.action == "applied"
+        assert len(responses.calls) == 3  # GET, DELETE, POST
+
+    @responses.activate
+    def test_not_protected_creates_new(self):
+        """Unprotected branch creates new protection."""
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123/protected_branches/main",
+            status=404,
+        )
+        responses.add(
+            responses.POST,
+            f"{MOCK_API_URL}/projects/123/protected_branches",
+            json={"name": "main"},
+        )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token")
+        args = make_args(branch="main", push="maintainer", merge="developer", unprotect=False, allow_force_push=False)
+        op = ProtectBranchOperation(client, args)
+        result = op.apply_to_project(123, "myorg/myproject")
+
+        assert result.action == "applied"
+        assert len(responses.calls) == 2  # GET (404), POST
+
+
+class TestProtectTagIdempotency:
+    """Tests for protect-tag idempotency."""
+
+    @responses.activate
+    def test_already_protected_same_settings(self):
+        """Tag already protected with same settings returns already_set."""
+        # Note: * is URL-encoded to %2A
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123/protected_tags/v1.2.%2A",
+            json={
+                "name": "v1.2.*",
+                "create_access_levels": [{"access_level": 40}],  # maintainer
+            },
+        )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token")
+        args = make_args(tag="v1.2.*", create="maintainer", unprotect=False)
+        op = ProtectTagOperation(client, args)
+        result = op.apply_to_project(123, "myorg/myproject")
+
+        assert result.action == "already_set"
+        assert len(responses.calls) == 1  # Only GET
+
+
+class TestProjectSettingIdempotency:
+    """Tests for project-setting idempotency."""
+
+    @responses.activate
+    def test_settings_already_match(self):
+        """Settings already matching returns already_set."""
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123",
+            json={
+                "id": 123,
+                "visibility": "private",
+                "merge_method": "ff",
+            },
+        )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token")
+        args = make_args(settings=["visibility=private", "merge_method=ff"])
+        op = ProjectSettingOperation(client, args)
+        result = op.apply_to_project(123, "myorg/myproject")
+
+        assert result.action == "already_set"
+        assert len(responses.calls) == 1  # Only GET
+
+    @responses.activate
+    def test_settings_different_updates(self):
+        """Different settings trigger update."""
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123",
+            json={
+                "id": 123,
+                "visibility": "public",  # Different
+                "merge_method": "merge",  # Different
+            },
+        )
+        responses.add(
+            responses.PUT,
+            f"{MOCK_API_URL}/projects/123",
+            json={"visibility": "private", "merge_method": "ff"},
+        )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token")
+        args = make_args(settings=["visibility=private", "merge_method=ff"])
+        op = ProjectSettingOperation(client, args)
+        result = op.apply_to_project(123, "myorg/myproject")
+
+        assert result.action == "applied"
+        assert len(responses.calls) == 2  # GET, PUT
+
+
+class TestApprovalRuleIdempotency:
+    """Tests for approval-rule idempotency."""
+
+    @responses.activate
+    def test_rule_already_exists_same_settings(self):
+        """Rule with same settings returns already_set."""
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123/approval_rules",
+            json=[
+                {
+                    "id": 1,
+                    "name": "Security Review",
+                    "approvals_required": 2,
+                    "users": [{"id": 100}, {"id": 101}],
+                }
+            ],
+        )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token")
+        args = make_args(
+            rule_name="Security Review",
+            approvals=None,  # Not changing
+            add_users=[],
+            remove_users=[],
+            unprotect=False,
+        )
+        op = ApprovalRuleOperation(client, args)
+        result = op.apply_to_project(123, "myorg/myproject")
+
+        assert result.action == "already_set"
+        assert len(responses.calls) == 1  # Only GET
+
+    @responses.activate
+    def test_rule_different_approvals_updates(self):
+        """Rule with different approval count triggers update."""
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123/approval_rules",
+            json=[
+                {
+                    "id": 1,
+                    "name": "Security Review",
+                    "approvals_required": 1,  # Different
+                    "users": [],
+                }
+            ],
+        )
+        responses.add(
+            responses.PUT,
+            f"{MOCK_API_URL}/projects/123/approval_rules/1",
+            json={"approvals_required": 2},
+        )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token")
+        args = make_args(
+            rule_name="Security Review",
+            approvals=2,
+            add_users=[],
+            remove_users=[],
+            unprotect=False,
+        )
+        op = ApprovalRuleOperation(client, args)
+        result = op.apply_to_project(123, "myorg/myproject")
+
+        assert result.action == "applied"
+        assert len(responses.calls) == 2  # GET, PUT

--- a/tests/test_recurse.py
+++ b/tests/test_recurse.py
@@ -1,0 +1,328 @@
+"""Integration tests for recursion and --filter flag."""
+
+import argparse
+import sys
+from pathlib import Path
+
+import pytest
+import responses
+
+# Add parent directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# Constants
+MOCK_GITLAB_URL = "https://gitlab.example.com"
+MOCK_API_URL = f"{MOCK_GITLAB_URL}/api/v4"
+
+
+def make_args(**kwargs) -> argparse.Namespace:
+    """Helper to create argparse.Namespace with default values."""
+    defaults = {
+        "dry_run": False,
+        "json_output": False,
+        "verbose": False,
+        "gitlab_url": None,
+        "max_retries": 3,
+        "filter_pattern": None,
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+from gl_settings import (
+    GitLabClient,
+    Target,
+    TargetType,
+    ProtectBranchOperation,
+    recurse,
+)
+
+
+class TestRecursion:
+    """Tests for group recursion."""
+
+    @responses.activate
+    def test_recurse_visits_all_projects(self, nested_group_structure):
+        """Recursion visits all projects in nested groups."""
+        struct = nested_group_structure
+
+        # Setup mock responses for group traversal
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/groups/1/subgroups",
+            json=struct["subgroups"],
+            headers={"x-total-pages": "1"},
+        )
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/groups/1/projects",
+            json=struct["root_projects"],
+            headers={"x-total-pages": "1"},
+        )
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/groups/2/subgroups",
+            json=[],
+            headers={"x-total-pages": "1"},
+        )
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/groups/2/projects",
+            json=struct["team_a_projects"],
+            headers={"x-total-pages": "1"},
+        )
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/groups/3/subgroups",
+            json=[],
+            headers={"x-total-pages": "1"},
+        )
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/groups/3/projects",
+            json=struct["team_b_projects"],
+            headers={"x-total-pages": "1"},
+        )
+
+        # Setup mock responses for branch protection checks
+        for project_id in [10, 11, 12]:
+            responses.add(
+                responses.GET,
+                f"{MOCK_API_URL}/projects/{project_id}/protected_branches/main",
+                status=404,
+            )
+            responses.add(
+                responses.POST,
+                f"{MOCK_API_URL}/projects/{project_id}/protected_branches",
+                json={"name": "main"},
+            )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token")
+        root_target = Target(
+            type=TargetType.GROUP,
+            id=1,
+            path="org",
+            name="org",
+            web_url=f"{MOCK_GITLAB_URL}/org",
+        )
+
+        args = make_args(branch="main", push="maintainer", merge="developer", unprotect=False, allow_force_push=False)
+        op = ProtectBranchOperation(client, args)
+
+        recurse(client, root_target, op)
+
+        # Should have 3 projects processed
+        assert len(op.results) == 3
+
+
+class TestFilterFlag:
+    """Tests for --filter flag functionality."""
+
+    @responses.activate
+    def test_filter_excludes_non_matching_projects(self, nested_group_structure):
+        """Filter pattern excludes projects that don't match."""
+        struct = nested_group_structure
+
+        # Setup mock responses for group traversal
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/groups/1/subgroups",
+            json=struct["subgroups"],
+            headers={"x-total-pages": "1"},
+        )
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/groups/1/projects",
+            json=struct["root_projects"],
+            headers={"x-total-pages": "1"},
+        )
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/groups/2/subgroups",
+            json=[],
+            headers={"x-total-pages": "1"},
+        )
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/groups/2/projects",
+            json=struct["team_a_projects"],
+            headers={"x-total-pages": "1"},
+        )
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/groups/3/subgroups",
+            json=[],
+            headers={"x-total-pages": "1"},
+        )
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/groups/3/projects",
+            json=struct["team_b_projects"],
+            headers={"x-total-pages": "1"},
+        )
+
+        # Only team-a projects should be processed (matching "org/team-a/*")
+        for project_id in [11, 12]:
+            responses.add(
+                responses.GET,
+                f"{MOCK_API_URL}/projects/{project_id}/protected_branches/main",
+                status=404,
+            )
+            responses.add(
+                responses.POST,
+                f"{MOCK_API_URL}/projects/{project_id}/protected_branches",
+                json={"name": "main"},
+            )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token")
+        root_target = Target(
+            type=TargetType.GROUP,
+            id=1,
+            path="org",
+            name="org",
+            web_url=f"{MOCK_GITLAB_URL}/org",
+        )
+
+        args = make_args(branch="main", push="maintainer", merge="developer", unprotect=False, allow_force_push=False)
+        op = ProtectBranchOperation(client, args)
+
+        # Filter to only team-a projects
+        recurse(client, root_target, op, filter_pattern="org/team-a/*")
+
+        # Should have only 2 projects processed (team-a/service, team-a/frontend)
+        assert len(op.results) == 2
+        for result in op.results:
+            assert "team-a" in result.target_path
+
+    @responses.activate
+    def test_filter_applies_to_direct_project_target(self):
+        """Filter applies even when target is a project directly."""
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token")
+        project_target = Target(
+            type=TargetType.PROJECT,
+            id=123,
+            path="myorg/other-project",  # Doesn't match filter
+            name="other-project",
+            web_url=f"{MOCK_GITLAB_URL}/myorg/other-project",
+        )
+
+        args = make_args(branch="main", push="maintainer", merge="developer", unprotect=False, allow_force_push=False)
+        op = ProtectBranchOperation(client, args)
+
+        # Filter for "myorg/myproject*" should skip "myorg/other-project"
+        recurse(client, project_target, op, filter_pattern="myorg/myproject*")
+
+        # Project should be skipped - no results
+        assert len(op.results) == 0
+
+    @responses.activate
+    def test_filter_matches_direct_project_target(self):
+        """Filter includes matching project when target is a project directly."""
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123/protected_branches/main",
+            status=404,
+        )
+        responses.add(
+            responses.POST,
+            f"{MOCK_API_URL}/projects/123/protected_branches",
+            json={"name": "main"},
+        )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token")
+        project_target = Target(
+            type=TargetType.PROJECT,
+            id=123,
+            path="myorg/myproject",  # Matches filter
+            name="myproject",
+            web_url=f"{MOCK_GITLAB_URL}/myorg/myproject",
+        )
+
+        args = make_args(branch="main", push="maintainer", merge="developer", unprotect=False, allow_force_push=False)
+        op = ProtectBranchOperation(client, args)
+
+        recurse(client, project_target, op, filter_pattern="myorg/myproject*")
+
+        # Project should be processed
+        assert len(op.results) == 1
+
+    @responses.activate
+    def test_groups_always_traversed_regardless_of_filter(self, nested_group_structure):
+        """Groups are always traversed even with a filter that wouldn't match the group path."""
+        struct = nested_group_structure
+
+        # Setup mock responses - all groups should be traversed
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/groups/1/subgroups",
+            json=struct["subgroups"],
+            headers={"x-total-pages": "1"},
+        )
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/groups/1/projects",
+            json=struct["root_projects"],
+            headers={"x-total-pages": "1"},
+        )
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/groups/2/subgroups",
+            json=[],
+            headers={"x-total-pages": "1"},
+        )
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/groups/2/projects",
+            json=struct["team_a_projects"],
+            headers={"x-total-pages": "1"},
+        )
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/groups/3/subgroups",
+            json=[],
+            headers={"x-total-pages": "1"},
+        )
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/groups/3/projects",
+            json=struct["team_b_projects"],
+            headers={"x-total-pages": "1"},
+        )
+
+        # Only one project should match the filter
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/11/protected_branches/main",
+            status=404,
+        )
+        responses.add(
+            responses.POST,
+            f"{MOCK_API_URL}/projects/11/protected_branches",
+            json={"name": "main"},
+        )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token")
+        root_target = Target(
+            type=TargetType.GROUP,
+            id=1,
+            path="org",
+            name="org",
+            web_url=f"{MOCK_GITLAB_URL}/org",
+        )
+
+        args = make_args(branch="main", push="maintainer", merge="developer", unprotect=False, allow_force_push=False)
+        op = ProtectBranchOperation(client, args)
+
+        # Filter for a very specific project
+        recurse(client, root_target, op, filter_pattern="org/team-a/service")
+
+        # Only 1 project should match
+        assert len(op.results) == 1
+        assert op.results[0].target_path == "org/team-a/service"
+
+        # But all subgroups should have been traversed (verify by checking call count)
+        # We should have: 3 subgroup GETs + 3 project GETs + 1 branch GET + 1 branch POST
+        subgroup_calls = [c for c in responses.calls if "/subgroups" in c.request.url]
+        # Note: project list calls have /groups/N/projects (may have query params)
+        project_list_calls = [c for c in responses.calls if "/groups/" in c.request.url and "/projects" in c.request.url]
+        assert len(subgroup_calls) == 3  # All groups traversed
+        assert len(project_list_calls) == 3  # All groups' projects queried

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,299 @@
+"""Tests for retry logic with exponential backoff."""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import requests
+import responses
+
+# Add parent directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# Constants
+MOCK_GITLAB_URL = "https://gitlab.example.com"
+MOCK_API_URL = f"{MOCK_GITLAB_URL}/api/v4"
+
+from gl_settings import (
+    GitLabClient,
+    RETRYABLE_STATUS_CODES,
+    RETRY_BACKOFF_FACTOR,
+    DEFAULT_MAX_RETRIES,
+)
+
+
+class TestRetryOn429:
+    """Tests for retry on rate limit (429) responses."""
+
+    @responses.activate
+    def test_429_triggers_retry(self):
+        """429 response triggers retry and eventually succeeds."""
+        # First call returns 429, second succeeds
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123",
+            status=429,
+            headers={"Retry-After": "0.1"},
+        )
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123",
+            json={"id": 123, "name": "test"},
+        )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", max_retries=3)
+        result = client.get("/projects/123")
+
+        assert result["id"] == 123
+        assert len(responses.calls) == 2
+
+    @responses.activate
+    def test_429_respects_retry_after_header(self):
+        """429 response uses Retry-After header for wait time."""
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123",
+            status=429,
+            headers={"Retry-After": "0.05"},  # 50ms
+        )
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123",
+            json={"id": 123},
+        )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", max_retries=3)
+
+        with patch("time.sleep") as mock_sleep:
+            client.get("/projects/123")
+            # Should have used Retry-After value
+            mock_sleep.assert_called_once()
+            assert mock_sleep.call_args[0][0] == 0.05
+
+
+class TestRetryOn5xx:
+    """Tests for retry on server error (5xx) responses."""
+
+    @responses.activate
+    def test_503_triggers_retry_with_backoff(self):
+        """503 response triggers retry with exponential backoff."""
+        responses.add(responses.GET, f"{MOCK_API_URL}/projects/123", status=503)
+        responses.add(responses.GET, f"{MOCK_API_URL}/projects/123", status=503)
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123",
+            json={"id": 123},
+        )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", max_retries=3)
+
+        with patch("time.sleep") as mock_sleep:
+            result = client.get("/projects/123")
+            assert result["id"] == 123
+            assert len(responses.calls) == 3
+            # Should have slept twice (before 2nd and 3rd attempts)
+            assert mock_sleep.call_count == 2
+
+    @responses.activate
+    def test_all_retryable_status_codes(self):
+        """All status codes in RETRYABLE_STATUS_CODES trigger retries."""
+        for status_code in RETRYABLE_STATUS_CODES:
+            responses.reset()
+            responses.add(
+                responses.GET,
+                f"{MOCK_API_URL}/projects/123",
+                status=status_code,
+            )
+            responses.add(
+                responses.GET,
+                f"{MOCK_API_URL}/projects/123",
+                json={"id": 123},
+            )
+
+            client = GitLabClient(MOCK_GITLAB_URL, "test-token", max_retries=1)
+
+            with patch("time.sleep"):
+                result = client.get("/projects/123")
+                assert result["id"] == 123, f"Failed for status code {status_code}"
+
+
+class TestRetryOnConnectionError:
+    """Tests for retry on connection errors."""
+
+    @responses.activate
+    def test_connection_error_triggers_retry(self):
+        """Connection error triggers retry."""
+        # Use callback to raise ConnectionError first, then succeed
+        call_count = [0]
+
+        def request_callback(request):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise requests.exceptions.ConnectionError("Connection refused")
+            return (200, {}, '{"id": 123}')
+
+        responses.add_callback(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123",
+            callback=request_callback,
+        )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", max_retries=3)
+
+        with patch("time.sleep"):
+            result = client.get("/projects/123")
+            assert result["id"] == 123
+            assert call_count[0] == 2
+
+
+class TestMaxRetriesExceeded:
+    """Tests for behavior when max retries are exceeded."""
+
+    @responses.activate
+    def test_raises_after_max_retries_5xx(self):
+        """Raises HTTPError after max retries exceeded for 5xx."""
+        for _ in range(DEFAULT_MAX_RETRIES + 1):
+            responses.add(responses.GET, f"{MOCK_API_URL}/projects/123", status=503)
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", max_retries=DEFAULT_MAX_RETRIES)
+
+        with patch("time.sleep"):
+            with pytest.raises(requests.HTTPError) as exc_info:
+                client.get("/projects/123")
+            assert exc_info.value.response.status_code == 503
+
+    @responses.activate
+    def test_raises_after_max_retries_connection_error(self):
+        """Raises ConnectionError after max retries exceeded."""
+
+        def always_fail(request):
+            raise requests.exceptions.ConnectionError("Connection refused")
+
+        responses.add_callback(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123",
+            callback=always_fail,
+        )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", max_retries=2)
+
+        with patch("time.sleep"):
+            with pytest.raises(requests.exceptions.ConnectionError):
+                client.get("/projects/123")
+
+
+class TestNoRetryOn4xx:
+    """Tests that 4xx errors (except 429) are not retried."""
+
+    @responses.activate
+    def test_400_not_retried(self):
+        """400 Bad Request is not retried."""
+        responses.add(responses.GET, f"{MOCK_API_URL}/projects/123", status=400)
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", max_retries=3)
+
+        with pytest.raises(requests.HTTPError):
+            client.get("/projects/123")
+
+        assert len(responses.calls) == 1  # No retry
+
+    @responses.activate
+    def test_403_not_retried(self):
+        """403 Forbidden is not retried."""
+        responses.add(responses.GET, f"{MOCK_API_URL}/projects/123", status=403)
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", max_retries=3)
+
+        with pytest.raises(requests.HTTPError):
+            client.get("/projects/123")
+
+        assert len(responses.calls) == 1  # No retry
+
+    @responses.activate
+    def test_404_not_retried(self):
+        """404 Not Found is not retried."""
+        responses.add(responses.GET, f"{MOCK_API_URL}/projects/123", status=404)
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", max_retries=3)
+
+        with pytest.raises(requests.HTTPError):
+            client.get("/projects/123")
+
+        assert len(responses.calls) == 1  # No retry
+
+
+class TestBackoffCalculation:
+    """Tests for exponential backoff calculation."""
+
+    def test_backoff_increases_exponentially(self):
+        """Backoff time increases exponentially with attempts."""
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token")
+
+        # Create a mock response without Retry-After
+        mock_response = requests.Response()
+        mock_response.status_code = 503
+        mock_response.headers = {}
+
+        # Attempt 0: 0.5 * (2^0) = 0.5
+        assert client._calculate_backoff(mock_response, 0) == RETRY_BACKOFF_FACTOR * 1
+        # Attempt 1: 0.5 * (2^1) = 1.0
+        assert client._calculate_backoff(mock_response, 1) == RETRY_BACKOFF_FACTOR * 2
+        # Attempt 2: 0.5 * (2^2) = 2.0
+        assert client._calculate_backoff(mock_response, 2) == RETRY_BACKOFF_FACTOR * 4
+
+    def test_429_uses_retry_after_not_exponential(self):
+        """429 with Retry-After header uses header value, not exponential."""
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token")
+
+        mock_response = requests.Response()
+        mock_response.status_code = 429
+        mock_response.headers = {"Retry-After": "5.5"}
+
+        # Should use Retry-After value regardless of attempt number
+        assert client._calculate_backoff(mock_response, 0) == 5.5
+        assert client._calculate_backoff(mock_response, 5) == 5.5
+
+    def test_429_without_retry_after_uses_exponential(self):
+        """429 without Retry-After header falls back to exponential backoff."""
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token")
+
+        mock_response = requests.Response()
+        mock_response.status_code = 429
+        mock_response.headers = {}  # No Retry-After
+
+        assert client._calculate_backoff(mock_response, 0) == RETRY_BACKOFF_FACTOR * 1
+        assert client._calculate_backoff(mock_response, 1) == RETRY_BACKOFF_FACTOR * 2
+
+
+class TestCustomMaxRetries:
+    """Tests for custom max_retries configuration."""
+
+    @responses.activate
+    def test_custom_max_retries_respected(self):
+        """Custom max_retries value is respected."""
+        # Add 2 failures + 1 success = 3 total calls needed
+        responses.add(responses.GET, f"{MOCK_API_URL}/projects/123", status=503)
+        responses.add(responses.GET, f"{MOCK_API_URL}/projects/123", status=503)
+        responses.add(responses.GET, f"{MOCK_API_URL}/projects/123", json={"id": 123})
+
+        # With max_retries=1, should fail (only 2 attempts: initial + 1 retry)
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", max_retries=1)
+
+        with patch("time.sleep"):
+            with pytest.raises(requests.HTTPError):
+                client.get("/projects/123")
+
+        assert len(responses.calls) == 2  # initial + 1 retry
+
+    @responses.activate
+    def test_zero_retries_no_retry(self):
+        """max_retries=0 means no retries."""
+        responses.add(responses.GET, f"{MOCK_API_URL}/projects/123", status=503)
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", max_retries=0)
+
+        with pytest.raises(requests.HTTPError):
+            client.get("/projects/123")
+
+        assert len(responses.calls) == 1  # Only initial attempt

--- a/tests/test_url_parsing.py
+++ b/tests/test_url_parsing.py
@@ -1,0 +1,111 @@
+"""Unit tests for URL parsing in GitLabClient._extract_path_from_url()."""
+
+import pytest
+
+# Constants (also defined in conftest.py for fixtures)
+MOCK_GITLAB_URL = "https://gitlab.example.com"
+
+
+class TestExtractPathFromUrl:
+    """Tests for _extract_path_from_url method."""
+
+    def test_full_https_url(self, mock_client):
+        """Full HTTPS URL extracts path correctly."""
+        result = mock_client._extract_path_from_url("https://gitlab.com/org/project")
+        assert result == "org/project"
+
+    def test_full_http_url(self, mock_client):
+        """Full HTTP URL extracts path correctly."""
+        result = mock_client._extract_path_from_url("http://gitlab.com/org/project")
+        assert result == "org/project"
+
+    def test_url_with_trailing_slash(self, mock_client):
+        """URL with trailing slash handles correctly."""
+        result = mock_client._extract_path_from_url("https://gitlab.com/org/project/")
+        assert result == "org/project"
+
+    def test_url_with_git_suffix(self, mock_client):
+        """URL with .git suffix strips it."""
+        result = mock_client._extract_path_from_url("https://gitlab.com/org/project.git")
+        assert result == "org/project"
+
+    def test_url_with_settings_path(self, mock_client):
+        """URL with /-/ settings path strips it."""
+        result = mock_client._extract_path_from_url(
+            "https://gitlab.com/org/project/-/settings/repository"
+        )
+        assert result == "org/project"
+
+    def test_url_with_hyphen_only(self, mock_client):
+        """URL with /- path strips it."""
+        result = mock_client._extract_path_from_url("https://gitlab.com/org/project/-")
+        assert result == "org/project"
+
+    def test_bare_path_simple(self, mock_client):
+        """Bare path without URL scheme."""
+        result = mock_client._extract_path_from_url("org/project")
+        assert result == "org/project"
+
+    def test_bare_path_with_slashes(self, mock_client):
+        """Bare path with leading/trailing slashes."""
+        result = mock_client._extract_path_from_url("/org/project/")
+        assert result == "org/project"
+
+    def test_single_segment(self, mock_client):
+        """Single segment (group only)."""
+        result = mock_client._extract_path_from_url("myorg")
+        assert result == "myorg"
+
+    def test_single_segment_url(self, mock_client):
+        """Single segment in URL form."""
+        result = mock_client._extract_path_from_url("https://gitlab.com/myorg")
+        assert result == "myorg"
+
+    def test_deeply_nested_path(self, mock_client):
+        """Deeply nested group/project path."""
+        result = mock_client._extract_path_from_url(
+            "https://gitlab.com/org/team/subteam/project"
+        )
+        assert result == "org/team/subteam/project"
+
+    def test_deeply_nested_bare_path(self, mock_client):
+        """Deeply nested bare path."""
+        result = mock_client._extract_path_from_url("org/team/sub/project")
+        assert result == "org/team/sub/project"
+
+    def test_url_with_tree_path(self, mock_client):
+        """URL pointing to a branch/tree strips the extra path."""
+        # Note: Current implementation would include /-/ so this tests the /-/ stripping
+        result = mock_client._extract_path_from_url(
+            "https://gitlab.com/org/project/-/tree/main"
+        )
+        assert result == "org/project"
+
+    def test_url_with_merge_requests_path(self, mock_client):
+        """URL pointing to merge requests strips the extra path."""
+        result = mock_client._extract_path_from_url(
+            "https://gitlab.com/org/project/-/merge_requests"
+        )
+        assert result == "org/project"
+
+    def test_custom_gitlab_instance(self, mock_client):
+        """URL from custom GitLab instance."""
+        result = mock_client._extract_path_from_url(
+            "https://gitlab.mycompany.com/team/service"
+        )
+        assert result == "team/service"
+
+    def test_path_with_dots(self, mock_client):
+        """Path containing dots (not .git suffix)."""
+        result = mock_client._extract_path_from_url("https://gitlab.com/org/my.project.name")
+        assert result == "org/my.project.name"
+
+    def test_path_with_hyphens(self, mock_client):
+        """Path containing hyphens."""
+        result = mock_client._extract_path_from_url("https://gitlab.com/my-org/my-project")
+        assert result == "my-org/my-project"
+
+    def test_path_with_underscores(self, mock_client):
+        """Path containing underscores."""
+        result = mock_client._extract_path_from_url("https://gitlab.com/my_org/my_project")
+        assert result == "my_org/my_project"


### PR DESCRIPTION
## Summary
- Add comprehensive pytest test suite with 55 tests covering all operations
- Test URL parsing (18 tests), idempotency (7 tests), dry-run safety (9 tests), recursion/filtering (5 tests), and retry logic (16 tests)
- Add shared fixtures in conftest.py for reusable mock GitLab client and sample data

## Test plan
- [x] `pytest tests/ -v` passes (55 tests in 0.22s)
- [x] Verify URL parsing handles all edge cases (trailing slashes, .git suffix, /-/ paths)
- [x] Verify idempotency returns `already_set` when no changes needed
- [x] Verify dry-run mode never calls POST/PUT/DELETE methods
- [x] Verify --filter flag excludes non-matching projects but traverses all groups

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)