### PR TITLE
fix(init-project): reorder steps so templates install before branch protection

### DIFF
--- a/gl_settings/operations/init_project.py
+++ b/gl_settings/operations/init_project.py
@@ -107,22 +107,23 @@ class InitProjectOperation(Operation):
             result = self._create_release_branch(project_id, project_path)
             results.append(result)
 
-        # 4. Protected branches
+        # 4. Issue templates (before branch protection, since protection
+        #    blocks commits and templates use the Repository Files API)
+        if not self.args.skip_templates:
+            for template in self.DEFAULT_TEMPLATES:
+                result = self._install_template(project_id, project_path, template)
+                results.append(result)
+
+        # 5. Protected branches (after templates, since release/* has no_access push)
         if not self.args.skip_branches:
             for branch, (push, merge, force_push) in self.DEFAULT_PROTECTED_BRANCHES.items():
                 result = self._protect_branch(project_id, project_path, branch, push, merge, force_push)
                 results.append(result)
 
-        # 5. Protected tags
+        # 6. Protected tags
         if not self.args.skip_tags:
             for tag, create_level in self.DEFAULT_PROTECTED_TAGS.items():
                 result = self._protect_tag(project_id, project_path, tag, create_level)
-                results.append(result)
-
-        # 6. Issue templates
-        if not self.args.skip_templates:
-            for template in self.DEFAULT_TEMPLATES:
-                result = self._install_template(project_id, project_path, template)
                 results.append(result)
 
         # Summarize


### PR DESCRIPTION
## Summary

- Fix step ordering in `init-project` so issue templates are committed **before** branch protection locks down `release/*` with `no_access` push

## Problem

The previous order was:
1. Create release branch → 2. **Protect branches** (blocks push) → 3. **Install templates** (fails!)

## Fix

New order:
1. Project settings
2. MR approval settings
3. Create `release/0.0.1` + set as default
4. **Install templates** (commits while branch is still open)
5. **Protect branches** (locks down after content is in place)
6. Protect tags

## Test plan

- [x] 55 unit tests pass
- [x] `ruff check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)