### PR TITLE
feat(operations): add push-rule operation for branch_name_regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,39 @@ gl-settings merge-request-setting https://gitlab.com/myorg/internal \
 
 ---
 
+### `push-rule`
+
+Manage project push rules — currently the `branch_name_regex` field. Useful for widening branch-name policies at scale (e.g. to accept a new prefix like `kahuna/*` across many projects).
+
+```bash
+gl-settings push-rule <target> --branch-name-regex "<regex>"
+```
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `--branch-name-regex` | Yes | Regex all branch names must match |
+
+**Behavior:**
+
+- Per-project only (group URLs recurse over contained projects via the standard mechanism).
+- GitLab's push-rule API is asymmetric: the first write to a project uses `POST /projects/:id/push_rule`; updates use `PUT`. The operation handles both transparently.
+- Idempotent — GET first, no-op if the current regex matches desired.
+- `--dry-run` flags drift (`would_apply`) without writing.
+
+**Examples:**
+
+```bash
+# Widen regex across a whole group so kahuna/* branches are accepted
+gl-settings push-rule https://gitlab.com/myorg \
+    --branch-name-regex '^(main|develop|kahuna/.*|feature/.*|fix/.*)$'
+
+# Dry-run to report which projects are drifted
+gl-settings --dry-run push-rule https://gitlab.com/myorg \
+    --branch-name-regex '^(main|develop|kahuna/.*|feature/.*|fix/.*)$'
+```
+
+---
+
 ## Global Flags
 
 | Flag | Description |

--- a/gl_settings/operations/__init__.py
+++ b/gl_settings/operations/__init__.py
@@ -9,6 +9,7 @@ from gl_settings.operations.project_setting import ProjectSettingOperation
 # Import all operations to register them
 from gl_settings.operations.protect_branch import ProtectBranchOperation
 from gl_settings.operations.protect_tag import ProtectTagOperation
+from gl_settings.operations.push_rule import PushRuleOperation
 
 __all__ = [
     "Operation",
@@ -20,4 +21,5 @@ __all__ = [
     "ApprovalRuleOperation",
     "MergeRequestSettingOperation",
     "InitProjectOperation",
+    "PushRuleOperation",
 ]

--- a/gl_settings/operations/push_rule.py
+++ b/gl_settings/operations/push_rule.py
@@ -1,0 +1,100 @@
+"""Push rule operation — manage project-level push rules (e.g. branch_name_regex)."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+import requests
+
+from gl_settings.models import ActionResult
+from gl_settings.operations.base import Operation, register_operation
+
+
+@register_operation("push-rule")
+class PushRuleOperation(Operation):
+    """Configure project push rules. Currently manages ``branch_name_regex``.
+
+    GitLab's push-rule endpoint is asymmetric: ``GET /projects/:id/push_rule``
+    returns 404 when no rule has ever been created, so the first write must
+    be a ``POST``; subsequent writes use ``PUT``.
+    """
+
+    @staticmethod
+    def add_arguments(parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            "--branch-name-regex",
+            required=True,
+            metavar="REGEX",
+            help=("Regex that branch names must match. Example: '^(main|develop|kahuna/.*|feature/.*|fix/.*)$'"),
+        )
+
+    def apply_to_project(self, project_id: int, project_path: str) -> ActionResult:
+        desired: dict[str, Any] = {"branch_name_regex": self.args.branch_name_regex}
+        endpoint = f"/projects/{project_id}/push_rule"
+
+        # GET current rule. 404 means no rule exists yet -> POST to create.
+        current: dict | None
+        try:
+            current = self.client.get(endpoint)
+        except requests.HTTPError as e:
+            if e.response is not None and e.response.status_code == 404:
+                current = None
+            else:
+                return self._record(
+                    ActionResult(
+                        target_type="project",
+                        target_path=project_path,
+                        target_id=project_id,
+                        operation="push-rule",
+                        action="error",
+                        detail=f"Failed to get push rule: {e}",
+                    )
+                )
+
+        if current is not None:
+            existing = current.get("branch_name_regex")
+            if existing == desired["branch_name_regex"]:
+                return self._record(
+                    ActionResult(
+                        target_type="project",
+                        target_path=project_path,
+                        target_id=project_id,
+                        operation="push-rule",
+                        action="already_set",
+                        detail=f"branch_name_regex: {existing!r}",
+                    )
+                )
+
+        action = "would_apply" if self.client.dry_run else "applied"
+        detail = f"branch_name_regex: {(current or {}).get('branch_name_regex')!r} -> {desired['branch_name_regex']!r}"
+
+        if not self.client.dry_run:
+            try:
+                if current is None:
+                    self.client.post(endpoint, data=desired)
+                else:
+                    self.client.put(endpoint, data=desired)
+            except requests.HTTPError as e:
+                return self._record(
+                    ActionResult(
+                        target_type="project",
+                        target_path=project_path,
+                        target_id=project_id,
+                        operation="push-rule",
+                        action="error",
+                        detail=f"Failed to apply push rule: {e}",
+                    )
+                )
+
+        return self._record(
+            ActionResult(
+                target_type="project",
+                target_path=project_path,
+                target_id=project_id,
+                operation="push-rule",
+                action=action,
+                detail=detail,
+                dry_run=self.client.dry_run,
+            )
+        )

--- a/tests/test_push_rule.py
+++ b/tests/test_push_rule.py
@@ -1,0 +1,213 @@
+"""Unit tests for the push-rule operation."""
+
+import argparse
+import sys
+from pathlib import Path
+
+import responses
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from gl_settings.client import GitLabClient
+from gl_settings.operations import PushRuleOperation
+
+MOCK_GITLAB_URL = "https://gitlab.example.com"
+MOCK_API_URL = f"{MOCK_GITLAB_URL}/api/v4"
+KAHUNA_REGEX = r"^(main|develop|kahuna/.*|feature/.*|fix/.*)$"
+
+
+def make_args(**kwargs) -> argparse.Namespace:
+    defaults = {
+        "dry_run": False,
+        "json_output": False,
+        "verbose": False,
+        "gitlab_url": None,
+        "max_retries": 3,
+        "filter_pattern": None,
+        "branch_name_regex": KAHUNA_REGEX,
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+class TestPushRuleCreation:
+    """First-time push rule creation: GET 404 -> POST."""
+
+    @responses.activate
+    def test_no_existing_rule_posts_new(self):
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123/push_rule",
+            status=404,
+        )
+        responses.add(
+            responses.POST,
+            f"{MOCK_API_URL}/projects/123/push_rule",
+            json={"branch_name_regex": KAHUNA_REGEX},
+            status=201,
+        )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token")
+        op = PushRuleOperation(client, make_args())
+        result = op.apply_to_project(123, "myorg/myproject")
+
+        assert result.action == "applied"
+        assert len(responses.calls) == 2  # GET(404), POST
+
+
+class TestPushRuleIdempotency:
+    """Existing rule with same regex -> skip."""
+
+    @responses.activate
+    def test_same_regex_is_already_set(self):
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123/push_rule",
+            json={"id": 1, "branch_name_regex": KAHUNA_REGEX},
+        )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token")
+        op = PushRuleOperation(client, make_args())
+        result = op.apply_to_project(123, "myorg/myproject")
+
+        assert result.action == "already_set"
+        assert len(responses.calls) == 1  # GET only, no write
+
+    @responses.activate
+    def test_different_regex_puts_update(self):
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123/push_rule",
+            json={"id": 1, "branch_name_regex": "^(main|develop)$"},
+        )
+        responses.add(
+            responses.PUT,
+            f"{MOCK_API_URL}/projects/123/push_rule",
+            json={"id": 1, "branch_name_regex": KAHUNA_REGEX},
+        )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token")
+        op = PushRuleOperation(client, make_args())
+        result = op.apply_to_project(123, "myorg/myproject")
+
+        assert result.action == "applied"
+        assert len(responses.calls) == 2  # GET, PUT
+
+
+class TestPushRuleDryRun:
+    """Dry-run should GET but never write."""
+
+    @responses.activate
+    def test_dry_run_no_existing_rule(self):
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123/push_rule",
+            status=404,
+        )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", dry_run=True)
+        op = PushRuleOperation(client, make_args())
+        result = op.apply_to_project(123, "myorg/myproject")
+
+        assert result.action == "would_apply"
+        assert result.dry_run is True
+        assert len(responses.calls) == 1  # GET only
+
+    @responses.activate
+    def test_dry_run_drift_detected(self):
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123/push_rule",
+            json={"id": 1, "branch_name_regex": "^(main|develop)$"},
+        )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", dry_run=True)
+        op = PushRuleOperation(client, make_args())
+        result = op.apply_to_project(123, "myorg/myproject")
+
+        assert result.action == "would_apply"
+        assert result.dry_run is True
+        assert len(responses.calls) == 1  # GET only, no PUT
+
+    @responses.activate
+    def test_dry_run_idempotent_still_skips(self):
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123/push_rule",
+            json={"id": 1, "branch_name_regex": KAHUNA_REGEX},
+        )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", dry_run=True)
+        op = PushRuleOperation(client, make_args())
+        result = op.apply_to_project(123, "myorg/myproject")
+
+        assert result.action == "already_set"
+        assert len(responses.calls) == 1
+
+
+class TestPushRuleErrors:
+    """Non-404 errors from GET and POST/PUT should surface as action=error."""
+
+    @responses.activate
+    def test_get_500_returns_error(self):
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123/push_rule",
+            status=500,
+        )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", max_retries=0)
+        op = PushRuleOperation(client, make_args())
+        result = op.apply_to_project(123, "myorg/myproject")
+
+        assert result.action == "error"
+        assert "Failed to get push rule" in (result.detail or "")
+
+    @responses.activate
+    def test_post_failure_returns_error(self):
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123/push_rule",
+            status=404,
+        )
+        responses.add(
+            responses.POST,
+            f"{MOCK_API_URL}/projects/123/push_rule",
+            status=403,
+        )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", max_retries=0)
+        op = PushRuleOperation(client, make_args())
+        result = op.apply_to_project(123, "myorg/myproject")
+
+        assert result.action == "error"
+        assert "Failed to apply push rule" in (result.detail or "")
+
+    @responses.activate
+    def test_put_failure_returns_error(self):
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/123/push_rule",
+            json={"id": 1, "branch_name_regex": "^(main|develop)$"},
+        )
+        responses.add(
+            responses.PUT,
+            f"{MOCK_API_URL}/projects/123/push_rule",
+            status=403,
+        )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", max_retries=0)
+        op = PushRuleOperation(client, make_args())
+        result = op.apply_to_project(123, "myorg/myproject")
+
+        assert result.action == "error"
+        assert "Failed to apply push rule" in (result.detail or "")
+
+
+class TestPushRuleGroupBehavior:
+    """push-rule is per-project only; applies_to_group must be False."""
+
+    def test_applies_to_group_false(self):
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token")
+        op = PushRuleOperation(client, make_args())
+        assert op.applies_to_group() is False


### PR DESCRIPTION
## Summary

Adds a per-project `push-rule` operation for GitLab's `PUT /projects/:id/push_rule` endpoint, specifically managing the `branch_name_regex` field. Formalizes the manual `glab api` sweep used to widen 29 projects' branch-name regexes to accept `kahuna/*` prefixes for the KAHUNA integration-branch pattern.

## Changes

- `gl_settings/operations/push_rule.py` (NEW, 100 lines) — `PushRuleOperation`, handles GitLab's asymmetric API (404→POST, exists→PUT)
- `gl_settings/operations/__init__.py` (+2) — registry import + export
- `tests/test_push_rule.py` (NEW, 213 lines) — 10 unit tests
- `README.md` (+33) — `### push-rule` section with usage + examples

## Linked Issues

Closes #26

## AC Notes

Spec AC item `--check mode reports drift correctly` does NOT introduce a new flag. The repo's existing convention is `--dry-run` + action codes: `would_apply` indicates drift, `already_set` indicates no drift. Three tests verify dry-run reports drift without writing. Open to reviewer push-back if a dedicated `--check` flag is wanted — happy to add it.

## Test Plan

- [x] \`ruff check gl_settings/ tests/\` → clean
- [x] \`ruff format --check\` → clean
- [x] \`make test\` → 65/65 passing (10 new + 55 existing; no regressions)
- [x] \`mypy gl_settings/\` → 0 new errors in \`push_rule.py\` (8 pre-existing errors in other files, unchanged)
- [x] \`trivy fs --severity HIGH,CRITICAL\` → 0 findings
- [x] Code-reviewer agent — no high-confidence issues found; API correctness/idempotency/error-paths/pattern-consistency all verified

## Coverage

- First-time creation (404 → POST)
- Idempotent same-regex (GET only, skip)
- Different regex (GET → PUT)
- Dry-run: no existing, drifted existing, idempotent
- Errors: GET 500, POST 403, PUT 403
- \`applies_to_group() is False\` (per-project only)