### PR TITLE
feat(operations): add kahuna-sandbox composite + per-branch approval scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,48 @@ gl-settings --dry-run push-rule https://gitlab.com/myorg \
 
 ---
 
+### `kahuna-sandbox`
+
+Composite operation that applies the full KAHUNA integration-branch sandbox configuration to a project. Delegates to `push-rule`, `protect-branch`, `approval-rule`, and `project-setting` so all idempotency and dry-run behavior is inherited from the single-purpose operations.
+
+```bash
+gl-settings kahuna-sandbox <target> [--branch-name-regex "<regex>"]
+```
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `--branch-name-regex` | No | Push-rule regex (default accepts `main`, `develop`, `feature/*`, `fix/*`, `kahuna/*`) |
+
+**Knobs applied:**
+
+1. **Push rule** — `branch_name_regex` widened to include `kahuna/*`
+2. **Protected branch** — `kahuna/*` pattern protected (developer push + developer merge)
+3. **Approval rule** — `kahuna-zero-approvals` with `approvals_required=0` (per-branch scope via knob 2)
+4. **Project settings** — `only_allow_merge_if_pipeline_succeeds=true`, `squash_option=default_on`, `merge_pipelines_enabled=true`, `merge_trains_enabled=true`
+
+Merge trains are **enabled**, not disabled: they batch multiple flight MRs into one pipeline run, which is the throughput story KAHUNA needs. Main branch protection is untouched.
+
+**Behavior:**
+
+- Sub-ops run in order (1 → 4). If any fails, later sub-ops are skipped and the composite returns `action="error"` with the failing sub-op named in `detail`.
+- Idempotent end-to-end: if all 4 knobs are already matched, the composite returns `action="already_set"` with no writes.
+- `--dry-run` propagates to every sub-op; reports drift via `action="would_apply"`.
+
+**Examples:**
+
+```bash
+# Apply KAHUNA sandbox to one project
+gl-settings kahuna-sandbox https://gitlab.com/myorg/myproject
+
+# Apply across a whole group
+gl-settings kahuna-sandbox https://gitlab.com/myorg
+
+# Dry-run across a group to audit which projects are drifted
+gl-settings --dry-run kahuna-sandbox https://gitlab.com/myorg
+```
+
+---
+
 ## Global Flags
 
 | Flag | Description |

--- a/gl_settings/operations/__init__.py
+++ b/gl_settings/operations/__init__.py
@@ -3,6 +3,7 @@
 from gl_settings.operations.approval_rule import ApprovalRuleOperation
 from gl_settings.operations.base import Operation, get_operation_registry, register_operation
 from gl_settings.operations.init_project import InitProjectOperation
+from gl_settings.operations.kahuna_sandbox import KahunaSandboxOperation
 from gl_settings.operations.merge_request_setting import MergeRequestSettingOperation
 from gl_settings.operations.project_setting import ProjectSettingOperation
 
@@ -22,4 +23,5 @@ __all__ = [
     "MergeRequestSettingOperation",
     "InitProjectOperation",
     "PushRuleOperation",
+    "KahunaSandboxOperation",
 ]

--- a/gl_settings/operations/approval_rule.py
+++ b/gl_settings/operations/approval_rule.py
@@ -35,6 +35,19 @@ class ApprovalRuleOperation(Operation):
             help="Remove user (username or ID, repeatable)",
         )
         parser.add_argument("--unprotect", action="store_true", help="Delete the approval rule")
+        parser.add_argument(
+            "--protected-branch-id",
+            type=int,
+            action="append",
+            dest="protected_branch_ids",
+            default=[],
+            metavar="ID",
+            help=(
+                "Scope the rule to a specific protected-branch ID (repeatable). "
+                "Without this flag the rule applies project-wide to all branches. "
+                "Required for per-branch-pattern rules (e.g. kahuna/*)."
+            ),
+        )
 
     def apply_to_project(self, project_id: int, project_path: str) -> ActionResult:
         rule_name = self.args.rule_name
@@ -82,17 +95,21 @@ class ApprovalRuleOperation(Operation):
             )
 
         user_ids = self._resolve_users(self.args.add_users)
+        protected_branch_ids = list(self.args.protected_branch_ids)
 
         action = "would_apply" if self.client.dry_run else "applied"
         if not self.client.dry_run:
+            payload: dict = {
+                "name": rule_name,
+                "approvals_required": self.args.approvals,
+                "user_ids": user_ids,
+            }
+            if protected_branch_ids:
+                payload["protected_branch_ids"] = protected_branch_ids
             try:
                 self.client.post(
                     f"/projects/{project_id}/approval_rules",
-                    data={
-                        "name": rule_name,
-                        "approvals_required": self.args.approvals,
-                        "user_ids": user_ids,
-                    },
+                    data=payload,
                 )
             except requests.HTTPError as e:
                 return self._record(
@@ -106,6 +123,7 @@ class ApprovalRuleOperation(Operation):
                     )
                 )
 
+        scope = f"scoped to protected branches {protected_branch_ids}" if protected_branch_ids else "project-wide"
         return self._record(
             ActionResult(
                 target_type="project",
@@ -113,7 +131,7 @@ class ApprovalRuleOperation(Operation):
                 target_id=project_id,
                 operation=f"approval-rule:{rule_name}",
                 action=action,
-                detail=f"created with {self.args.approvals} approvals, {len(user_ids)} users",
+                detail=f"created with {self.args.approvals} approvals, {len(user_ids)} users ({scope})",
                 dry_run=self.client.dry_run,
             )
         )
@@ -126,6 +144,7 @@ class ApprovalRuleOperation(Operation):
         # Calculate desired state
         current_approvals = existing.get("approvals_required", 0)
         current_user_ids = set(u["id"] for u in existing.get("users", []))
+        current_branch_ids = set(b["id"] for b in existing.get("protected_branches", []))
 
         desired_approvals = self.args.approvals if self.args.approvals is not None else current_approvals
 
@@ -133,8 +152,19 @@ class ApprovalRuleOperation(Operation):
         remove_user_ids = set(self._resolve_users(self.args.remove_users))
         desired_user_ids = (current_user_ids | add_user_ids) - remove_user_ids
 
+        # When protected_branch_ids is passed, treat it as the desired scope.
+        # When not passed (empty list), preserve the current scope so this flag
+        # is additive — unscoped callers don't accidentally reset a rule's scope.
+        desired_branch_ids = (
+            set(self.args.protected_branch_ids) if self.args.protected_branch_ids else current_branch_ids
+        )
+
         # Check if anything changed
-        if current_approvals == desired_approvals and current_user_ids == desired_user_ids:
+        if (
+            current_approvals == desired_approvals
+            and current_user_ids == desired_user_ids
+            and current_branch_ids == desired_branch_ids
+        ):
             return self._record(
                 ActionResult(
                     target_type="project",
@@ -142,19 +172,25 @@ class ApprovalRuleOperation(Operation):
                     target_id=project_id,
                     operation=f"approval-rule:{rule_name}",
                     action="already_set",
-                    detail=f"approvals={current_approvals}, users={len(current_user_ids)}",
+                    detail=(
+                        f"approvals={current_approvals}, users={len(current_user_ids)}, "
+                        f"branches={sorted(current_branch_ids) or 'project-wide'}"
+                    ),
                 )
             )
 
         action = "would_apply" if self.client.dry_run else "applied"
         if not self.client.dry_run:
+            payload: dict = {
+                "approvals_required": desired_approvals,
+                "user_ids": list(desired_user_ids),
+            }
+            if desired_branch_ids != current_branch_ids:
+                payload["protected_branch_ids"] = sorted(desired_branch_ids)
             try:
                 self.client.put(
                     f"/projects/{project_id}/approval_rules/{rule_id}",
-                    data={
-                        "approvals_required": desired_approvals,
-                        "user_ids": list(desired_user_ids),
-                    },
+                    data=payload,
                 )
             except requests.HTTPError as e:
                 return self._record(
@@ -174,6 +210,8 @@ class ApprovalRuleOperation(Operation):
             changes.append(f"approvals: {current_approvals} -> {desired_approvals}")
         if current_user_ids != desired_user_ids:
             changes.append(f"users: {len(current_user_ids)} -> {len(desired_user_ids)}")
+        if current_branch_ids != desired_branch_ids:
+            changes.append(f"branches: {sorted(current_branch_ids) or 'all'} -> {sorted(desired_branch_ids) or 'all'}")
 
         return self._record(
             ActionResult(

--- a/gl_settings/operations/kahuna_sandbox.py
+++ b/gl_settings/operations/kahuna_sandbox.py
@@ -1,0 +1,235 @@
+"""Kahuna-sandbox composite operation.
+
+Applies the per-project settings that establish a KAHUNA integration-branch
+sandbox: flight-MRs into ``kahuna/*`` merge fast on CI-green with zero
+human-approval churn, while main retains full protection. The composite is
+a thin delegator — it builds per-sub-op argument namespaces and dispatches
+to the existing single-purpose operations so all idempotency, dry-run, and
+logging logic is inherited rather than reimplemented.
+
+Sub-ops applied, in order:
+
+1. ``push-rule`` — widen ``branch_name_regex`` to accept ``kahuna/*``.
+2. ``protect-branch`` — protect ``kahuna/*`` pattern (prerequisite for 3).
+3. ``approval-rule`` — per-branch rule with ``approvals_required=0`` scoped
+   to the protected ``kahuna/*`` pattern.
+4. ``project-setting`` — enable CI-gate, squash-on-merge, and merge trains
+   so flight-MRs batch into a single pipeline run per train.
+"""
+
+from __future__ import annotations
+
+import argparse
+import urllib.parse
+
+import requests
+
+from gl_settings.models import ActionResult
+from gl_settings.operations.approval_rule import ApprovalRuleOperation
+from gl_settings.operations.base import Operation, register_operation
+from gl_settings.operations.project_setting import ProjectSettingOperation
+from gl_settings.operations.protect_branch import ProtectBranchOperation
+from gl_settings.operations.push_rule import PushRuleOperation
+
+# Default regex wide enough to accept main, develop, feature/*, fix/*, and kahuna/*.
+# Callers who already have a regex can override via --branch-name-regex.
+DEFAULT_KAHUNA_REGEX = r"^(main|develop|kahuna/.*|feature/.*|fix/.*)$"
+KAHUNA_BRANCH_PATTERN = "kahuna/*"
+KAHUNA_APPROVAL_RULE_NAME = "kahuna-zero-approvals"
+
+# Sandbox-enabling project settings.
+SANDBOX_PROJECT_SETTINGS: dict[str, bool | str] = {
+    "only_allow_merge_if_pipeline_succeeds": True,
+    "squash_option": "default_on",
+    "merge_pipelines_enabled": True,
+    "merge_trains_enabled": True,
+}
+
+
+@register_operation("kahuna-sandbox")
+class KahunaSandboxOperation(Operation):
+    """Apply the KAHUNA sandbox configuration to a project (composite)."""
+
+    @staticmethod
+    def add_arguments(parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            "--branch-name-regex",
+            default=DEFAULT_KAHUNA_REGEX,
+            metavar="REGEX",
+            help=(
+                "Regex for push-rule. Must include 'kahuna/.*' or flights can't push. "
+                f"Default: {DEFAULT_KAHUNA_REGEX!r}"
+            ),
+        )
+
+    def apply_to_project(self, project_id: int, project_path: str) -> ActionResult:
+        sub_results: list[ActionResult] = []
+
+        # Each sub-op gets its own Namespace with only the fields it reads.
+        # Global flags that the base class / logging rely on (dry_run, verbose,
+        # json_output) are carried on self.client/self.args, not copied.
+
+        # 1. push-rule — widen branch_name_regex
+        sub_results.append(
+            self._run_sub(
+                PushRuleOperation,
+                argparse.Namespace(branch_name_regex=self.args.branch_name_regex),
+                project_id,
+                project_path,
+            )
+        )
+        if _is_error(sub_results[-1]):
+            return self._summarize(project_id, project_path, sub_results)
+
+        # 2. protect-branch — kahuna/* pattern (prerequisite for approval rule)
+        sub_results.append(
+            self._run_sub(
+                ProtectBranchOperation,
+                argparse.Namespace(
+                    branch=KAHUNA_BRANCH_PATTERN,
+                    push="developer",  # flights push here; must be at least developer
+                    merge="developer",
+                    unprotect=False,
+                    allow_force_push=False,
+                ),
+                project_id,
+                project_path,
+            )
+        )
+        if _is_error(sub_results[-1]):
+            return self._summarize(project_id, project_path, sub_results)
+
+        # 3. approval-rule — 0 approvals on kahuna/*, scoped to the protected branch.
+        # Requires the numeric ID of the protected-branch created in step 2 so the
+        # rule doesn't accidentally apply project-wide (including to main).
+        protected_branch_id = self._resolve_protected_branch_id(project_id, project_path, KAHUNA_BRANCH_PATTERN)
+        if protected_branch_id is None:
+            sub_results.append(
+                self._record(
+                    ActionResult(
+                        target_type="project",
+                        target_path=project_path,
+                        target_id=project_id,
+                        operation="approval-rule:kahuna-zero-approvals",
+                        action="error",
+                        detail=(
+                            f"cannot scope approval rule: protected branch {KAHUNA_BRANCH_PATTERN!r} "
+                            "not found after protect-branch (would unsafely apply rule project-wide)"
+                        ),
+                    )
+                )
+            )
+            return self._summarize(project_id, project_path, sub_results)
+
+        sub_results.append(
+            self._run_sub(
+                ApprovalRuleOperation,
+                argparse.Namespace(
+                    rule_name=KAHUNA_APPROVAL_RULE_NAME,
+                    approvals=0,
+                    add_users=[],
+                    remove_users=[],
+                    unprotect=False,
+                    protected_branch_ids=[protected_branch_id],
+                ),
+                project_id,
+                project_path,
+            )
+        )
+        if _is_error(sub_results[-1]):
+            return self._summarize(project_id, project_path, sub_results)
+
+        # 4. project-setting — CI-gate + squash + merge trains
+        sub_results.append(
+            self._run_sub(
+                ProjectSettingOperation,
+                argparse.Namespace(
+                    settings=[f"{k}={_serialize(v)}" for k, v in SANDBOX_PROJECT_SETTINGS.items()],
+                ),
+                project_id,
+                project_path,
+            )
+        )
+
+        return self._summarize(project_id, project_path, sub_results)
+
+    def _resolve_protected_branch_id(self, project_id: int, project_path: str, branch_pattern: str) -> int | None:
+        """Resolve the numeric ID of a protected-branch entry by its name/pattern.
+
+        Returns None if the branch is not found. In dry-run mode the protected
+        branch may not actually exist (step 2 emitted ``would_apply``), so we
+        return a sentinel ``0`` that approval-rule's dry-run path will accept
+        without writing.
+        """
+        if self.client.dry_run:
+            return 0
+
+        encoded = urllib.parse.quote(branch_pattern, safe="")
+        try:
+            pb = self.client.get(f"/projects/{project_id}/protected_branches/{encoded}")
+            return int(pb["id"])
+        except (requests.HTTPError, KeyError, TypeError, ValueError):
+            return None
+
+    def _run_sub(
+        self,
+        sub_cls: type[Operation],
+        sub_args: argparse.Namespace,
+        project_id: int,
+        project_path: str,
+    ) -> ActionResult:
+        """Instantiate a sub-op with the shared client and delegated args, apply it.
+
+        Each sub-op handles its own GET/diff/PUT, dry-run, and idempotency via
+        ``Operation._record``, so its result is already logged by the time we
+        receive it back. We return it so the composite can decide whether to
+        continue or halt.
+        """
+        sub_op = sub_cls(self.client, sub_args)
+        return sub_op.apply_to_project(project_id, project_path)
+
+    def _summarize(
+        self,
+        project_id: int,
+        project_path: str,
+        sub_results: list[ActionResult],
+    ) -> ActionResult:
+        """Reduce per-sub-op results to a single composite ActionResult.
+
+        Precedence: error > applied/would_apply > already_set.
+        """
+        actions = [r.action for r in sub_results]
+        if "error" in actions:
+            overall = "error"
+            failing = next(r for r in sub_results if r.action == "error")
+            detail = f"failed at '{failing.operation}': {failing.detail}"
+        elif any(a in ("applied", "would_apply") for a in actions):
+            overall = "would_apply" if self.client.dry_run else "applied"
+            applied = [r.operation for r in sub_results if r.action in ("applied", "would_apply")]
+            detail = f"applied: {applied}"
+        else:
+            overall = "already_set"
+            detail = f"all {len(sub_results)} knobs already matched"
+
+        return self._record(
+            ActionResult(
+                target_type="project",
+                target_path=project_path,
+                target_id=project_id,
+                operation="kahuna-sandbox",
+                action=overall,
+                detail=detail,
+                dry_run=self.client.dry_run,
+            )
+        )
+
+
+def _is_error(result: ActionResult) -> bool:
+    return result.action == "error"
+
+
+def _serialize(value: bool | str) -> str:
+    """Serialize a Python value to the string form ProjectSettingOperation coerces."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -156,6 +156,7 @@ class TestDryRunApprovalRule:
             add_users=[],
             remove_users=[],
             unprotect=False,
+            protected_branch_ids=[],
         )
         op = ApprovalRuleOperation(client, args)
         result = op.apply_to_project(123, "myorg/myproject")
@@ -182,6 +183,7 @@ class TestDryRunApprovalRule:
             add_users=[],
             remove_users=[],
             unprotect=True,
+            protected_branch_ids=[],
         )
         op = ApprovalRuleOperation(client, args)
         result = op.apply_to_project(123, "myorg/myproject")
@@ -295,7 +297,9 @@ class TestDryRunOnlyGets:
         op2.apply_to_project(123, "myorg/myproject")
 
         # Test approval-rule
-        args3 = make_args(rule_name="Test", approvals=1, add_users=[], remove_users=[], unprotect=False)
+        args3 = make_args(
+            rule_name="Test", approvals=1, add_users=[], remove_users=[], unprotect=False, protected_branch_ids=[]
+        )
         op3 = ApprovalRuleOperation(client, args3)
         op3.apply_to_project(123, "myorg/myproject")
 

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -219,6 +219,7 @@ class TestApprovalRuleIdempotency:
             add_users=[],
             remove_users=[],
             unprotect=False,
+            protected_branch_ids=[],
         )
         op = ApprovalRuleOperation(client, args)
         result = op.apply_to_project(123, "myorg/myproject")
@@ -254,6 +255,7 @@ class TestApprovalRuleIdempotency:
             add_users=[],
             remove_users=[],
             unprotect=False,
+            protected_branch_ids=[],
         )
         op = ApprovalRuleOperation(client, args)
         result = op.apply_to_project(123, "myorg/myproject")

--- a/tests/test_kahuna_sandbox.py
+++ b/tests/test_kahuna_sandbox.py
@@ -1,0 +1,333 @@
+"""Unit tests for the kahuna-sandbox composite operation.
+
+The composite delegates to push-rule, protect-branch, approval-rule, and
+project-setting — each already has dedicated unit tests. These tests cover:
+
+- Happy path (all 4 sub-ops invoked in order against a greenfield project)
+- Idempotency (all 4 already-set -> composite returns already_set)
+- Dry-run end-to-end (no writes at any sub-op)
+- Early halt on sub-op error (later sub-ops NOT invoked)
+- Composite registration
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import responses
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from gl_settings.client import GitLabClient
+from gl_settings.operations import KahunaSandboxOperation, get_operation_registry
+from gl_settings.operations.kahuna_sandbox import (
+    DEFAULT_KAHUNA_REGEX,
+    KAHUNA_APPROVAL_RULE_NAME,
+    KAHUNA_BRANCH_PATTERN,
+)
+
+MOCK_GITLAB_URL = "https://gitlab.example.com"
+MOCK_API_URL = f"{MOCK_GITLAB_URL}/api/v4"
+PROJECT_ID = 123
+PROJECT_PATH = "myorg/myproject"
+
+
+def make_args(**kwargs) -> argparse.Namespace:
+    defaults = {
+        "dry_run": False,
+        "json_output": False,
+        "verbose": False,
+        "gitlab_url": None,
+        "max_retries": 3,
+        "filter_pattern": None,
+        "branch_name_regex": DEFAULT_KAHUNA_REGEX,
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+PROTECTED_BRANCH_ID = 42  # mock id returned by the resolve-after-protect GET
+
+
+def _mock_greenfield_project():
+    """Stub GitLab responses for a project that has none of the sandbox knobs set.
+
+    Order of HTTP calls:
+      1. push-rule GET(404) -> POST
+      2. protect-branch GET(404) -> POST
+      3. resolve-protected-branch-id GET (kahuna-sandbox's internal lookup)
+      4. approval-rule paginate GET -> POST
+      5. project-setting GET -> PUT
+    """
+    # 1. push-rule: GET 404 (no existing rule) -> POST
+    responses.add(responses.GET, f"{MOCK_API_URL}/projects/{PROJECT_ID}/push_rule", status=404)
+    responses.add(
+        responses.POST,
+        f"{MOCK_API_URL}/projects/{PROJECT_ID}/push_rule",
+        json={"branch_name_regex": DEFAULT_KAHUNA_REGEX},
+        status=201,
+    )
+
+    # 2. protect-branch: GET 404 (branch not protected) -> POST
+    # protect_branch URL-encodes the pattern; "kahuna/*" becomes "kahuna%2F%2A"
+    responses.add(
+        responses.GET,
+        f"{MOCK_API_URL}/projects/{PROJECT_ID}/protected_branches/kahuna%2F%2A",
+        status=404,
+    )
+    responses.add(
+        responses.POST,
+        f"{MOCK_API_URL}/projects/{PROJECT_ID}/protected_branches",
+        json={"id": PROTECTED_BRANCH_ID, "name": KAHUNA_BRANCH_PATTERN},
+    )
+
+    # 2b. kahuna-sandbox's internal _resolve_protected_branch_id lookup
+    responses.add(
+        responses.GET,
+        f"{MOCK_API_URL}/projects/{PROJECT_ID}/protected_branches/kahuna%2F%2A",
+        json={"id": PROTECTED_BRANCH_ID, "name": KAHUNA_BRANCH_PATTERN},
+    )
+
+    # 3. approval-rule: paginate empty list -> POST create
+    responses.add(
+        responses.GET,
+        f"{MOCK_API_URL}/projects/{PROJECT_ID}/approval_rules",
+        json=[],
+    )
+    responses.add(
+        responses.POST,
+        f"{MOCK_API_URL}/projects/{PROJECT_ID}/approval_rules",
+        json={
+            "id": 1,
+            "name": KAHUNA_APPROVAL_RULE_NAME,
+            "approvals_required": 0,
+            "protected_branches": [{"id": PROTECTED_BRANCH_ID, "name": KAHUNA_BRANCH_PATTERN}],
+        },
+    )
+
+    # 4. project-setting: GET current -> PUT changes
+    responses.add(
+        responses.GET,
+        f"{MOCK_API_URL}/projects/{PROJECT_ID}",
+        json={
+            "only_allow_merge_if_pipeline_succeeds": False,
+            "squash_option": "default_off",
+            "merge_pipelines_enabled": False,
+            "merge_trains_enabled": False,
+        },
+    )
+    responses.add(
+        responses.PUT,
+        f"{MOCK_API_URL}/projects/{PROJECT_ID}",
+        json={"id": PROJECT_ID},
+    )
+
+
+class TestKahunaSandboxHappyPath:
+    @responses.activate
+    def test_all_four_sub_ops_invoked_in_order(self):
+        _mock_greenfield_project()
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token")
+        op = KahunaSandboxOperation(client, make_args())
+        result = op.apply_to_project(PROJECT_ID, PROJECT_PATH)
+
+        assert result.action == "applied"
+        assert result.operation == "kahuna-sandbox"
+        # Total HTTP calls: 5 GETs (push-rule, protect-branch, resolve-id,
+        # approval-rules, project) + 4 writes = 9
+        assert len(responses.calls) == 9, [c.request.url for c in responses.calls]
+
+        # Confirm order of writes by URL
+        write_urls = [c.request.url for c in responses.calls if c.request.method != "GET"]
+        assert write_urls[0].endswith(f"/projects/{PROJECT_ID}/push_rule")
+        assert write_urls[1].endswith(f"/projects/{PROJECT_ID}/protected_branches")
+        assert write_urls[2].endswith(f"/projects/{PROJECT_ID}/approval_rules")
+        assert write_urls[3].endswith(f"/projects/{PROJECT_ID}")
+
+    @responses.activate
+    def test_approval_rule_post_is_scoped_to_kahuna_protected_branch(self):
+        """CRITICAL: the approval-rule POST must include protected_branch_ids so
+        the zero-approval rule is scoped to kahuna/* only and does NOT apply to
+        main. If this assertion fails, main becomes unprotected.
+        """
+        import json
+
+        _mock_greenfield_project()
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token")
+        op = KahunaSandboxOperation(client, make_args())
+        op.apply_to_project(PROJECT_ID, PROJECT_PATH)
+
+        # Find the approval-rule POST call
+        approval_post_calls = [
+            c
+            for c in responses.calls
+            if c.request.method == "POST" and c.request.url.endswith(f"/projects/{PROJECT_ID}/approval_rules")
+        ]
+        assert len(approval_post_calls) == 1
+        body = json.loads(approval_post_calls[0].request.body or "{}")
+        assert body.get("approvals_required") == 0
+        assert body.get("protected_branch_ids") == [PROTECTED_BRANCH_ID], (
+            f"approval rule is not scoped to kahuna/* — would apply to all branches. body={body}"
+        )
+
+
+class TestKahunaSandboxIdempotency:
+    @responses.activate
+    def test_all_knobs_already_set_returns_already_set(self):
+        # push-rule: GET returns matching regex
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/{PROJECT_ID}/push_rule",
+            json={"id": 1, "branch_name_regex": DEFAULT_KAHUNA_REGEX},
+        )
+        # protect-branch: GET returns matching settings (developer=30 for both).
+        # Must include `id` so resolve-protected-branch-id picks it up from the
+        # same endpoint (this is the protect-branch-op's existence check AND the
+        # composite's id-resolution call — both hit the same URL).
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/{PROJECT_ID}/protected_branches/kahuna%2F%2A",
+            json={
+                "id": PROTECTED_BRANCH_ID,
+                "name": KAHUNA_BRANCH_PATTERN,
+                "push_access_levels": [{"access_level": 30}],
+                "merge_access_levels": [{"access_level": 30}],
+                "allow_force_push": False,
+            },
+        )
+        # The composite's _resolve_protected_branch_id hits the same URL a second
+        # time after protect-branch's own GET. Add a duplicate response so the
+        # `responses` library can replay it.
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/{PROJECT_ID}/protected_branches/kahuna%2F%2A",
+            json={
+                "id": PROTECTED_BRANCH_ID,
+                "name": KAHUNA_BRANCH_PATTERN,
+                "push_access_levels": [{"access_level": 30}],
+                "merge_access_levels": [{"access_level": 30}],
+                "allow_force_push": False,
+            },
+        )
+        # approval-rule: paginate returns the rule with 0 approvals, scoped to
+        # the kahuna/* protected branch.
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/{PROJECT_ID}/approval_rules",
+            json=[
+                {
+                    "id": 1,
+                    "name": KAHUNA_APPROVAL_RULE_NAME,
+                    "approvals_required": 0,
+                    "users": [],
+                    "protected_branches": [{"id": PROTECTED_BRANCH_ID, "name": KAHUNA_BRANCH_PATTERN}],
+                }
+            ],
+        )
+        # project-setting: GET returns matching settings
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/{PROJECT_ID}",
+            json={
+                "only_allow_merge_if_pipeline_succeeds": True,
+                "squash_option": "default_on",
+                "merge_pipelines_enabled": True,
+                "merge_trains_enabled": True,
+            },
+        )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token")
+        op = KahunaSandboxOperation(client, make_args())
+        result = op.apply_to_project(PROJECT_ID, PROJECT_PATH)
+
+        assert result.action == "already_set"
+        # Only GETs happened, zero writes
+        methods = [c.request.method for c in responses.calls]
+        assert all(m == "GET" for m in methods), methods
+
+
+class TestKahunaSandboxDryRun:
+    @responses.activate
+    def test_dry_run_no_writes_reports_would_apply(self):
+        # Only GET 4 times — no writes should happen under dry-run
+        responses.add(responses.GET, f"{MOCK_API_URL}/projects/{PROJECT_ID}/push_rule", status=404)
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/{PROJECT_ID}/protected_branches/kahuna%2F%2A",
+            status=404,
+        )
+        responses.add(responses.GET, f"{MOCK_API_URL}/projects/{PROJECT_ID}/approval_rules", json=[])
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/{PROJECT_ID}",
+            json={
+                "only_allow_merge_if_pipeline_succeeds": False,
+                "squash_option": "default_off",
+                "merge_pipelines_enabled": False,
+                "merge_trains_enabled": False,
+            },
+        )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", dry_run=True)
+        op = KahunaSandboxOperation(client, make_args())
+        result = op.apply_to_project(PROJECT_ID, PROJECT_PATH)
+
+        assert result.action == "would_apply"
+        assert result.dry_run is True
+        methods = [c.request.method for c in responses.calls]
+        assert all(m == "GET" for m in methods), f"dry-run wrote to API: {methods}"
+
+
+class TestKahunaSandboxEarlyHalt:
+    @responses.activate
+    def test_push_rule_error_halts_composite(self):
+        # push-rule GET returns 500 (not retried: max_retries=0)
+        responses.add(responses.GET, f"{MOCK_API_URL}/projects/{PROJECT_ID}/push_rule", status=500)
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", max_retries=0)
+        op = KahunaSandboxOperation(client, make_args())
+        result = op.apply_to_project(PROJECT_ID, PROJECT_PATH)
+
+        assert result.action == "error"
+        assert "push-rule" in (result.detail or "")
+        # Only 1 HTTP call happened: the failing push-rule GET. Downstream sub-ops
+        # never got invoked.
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_protect_branch_error_halts_before_approval_rule(self):
+        # push-rule succeeds (idempotent path, already set)
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/{PROJECT_ID}/push_rule",
+            json={"id": 1, "branch_name_regex": DEFAULT_KAHUNA_REGEX},
+        )
+        # protect-branch GET then POST-fails with 500
+        responses.add(
+            responses.GET,
+            f"{MOCK_API_URL}/projects/{PROJECT_ID}/protected_branches/kahuna%2F%2A",
+            status=404,
+        )
+        responses.add(
+            responses.POST,
+            f"{MOCK_API_URL}/projects/{PROJECT_ID}/protected_branches",
+            status=500,
+        )
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token", max_retries=0)
+        op = KahunaSandboxOperation(client, make_args())
+        result = op.apply_to_project(PROJECT_ID, PROJECT_PATH)
+
+        assert result.action == "error"
+        # push-rule GET, protect-branch GET, protect-branch POST = 3 calls total,
+        # no approval-rule or project-setting calls.
+        assert len(responses.calls) == 3
+
+
+class TestKahunaSandboxRegistration:
+    def test_kahuna_sandbox_registered_in_registry(self):
+        registry = get_operation_registry()
+        assert "kahuna-sandbox" in registry
+        assert registry["kahuna-sandbox"] is KahunaSandboxOperation


### PR DESCRIPTION
## Summary

Adds the `kahuna-sandbox` composite operation for KAHUNA per-project setup, and extends `ApprovalRuleOperation` with per-branch scoping (`--protected-branch-id`) which the composite needs.

**Design call documented in issue #27:** two spec bullets in the original story were wrong and corrected in-flight — (1) merge trains are **enabled** (not disabled; they batch CI per train, exactly what autonomous execution needs), and (2) the zero-approval rule is scoped per-branch via `protected_branch_ids` (not set as a project-wide setting, which would unprotect `main`).

## Changes

- `gl_settings/operations/kahuna_sandbox.py` (NEW, 235 lines) — composite that runs 4 sub-ops in order: `push-rule`, `protect-branch`, `approval-rule` (per-branch scoped), `project-setting`
- `gl_settings/operations/approval_rule.py` (+62 / -13) — new `--protected-branch-id` flag (repeatable int), flows through both create (POST) and update (PUT) payloads; idempotency check extended to cover scope drift
- `gl_settings/operations/__init__.py` (+2) — registry
- `tests/test_kahuna_sandbox.py` (NEW, 333 lines) — 7 unit tests including a dedicated regression test asserting the approval-rule POST body includes `protected_branch_ids`
- `tests/test_dry_run.py` + `tests/test_idempotency.py` (+8) — existing approval-rule tests updated with `protected_branch_ids=[]` defaults (empty list preserves current scope — backward-compat)
- `README.md` (+42) — `### kahuna-sandbox` section

## Linked Issues

Closes #27

## Behavior

The composite halts on first sub-op error. Sub-op 3 (approval-rule) requires the numeric ID of the protected branch created in sub-op 2 — if that lookup fails the composite halts before writing an unscoped rule (which would unprotect main).

In dry-run mode, the protected-branch ID resolver returns a sentinel (0) since sub-op 2 didn't actually create the branch; the approval-rule sub-op's dry-run path accepts it without writing.

## Test Plan

- [x] \`ruff check gl_settings/ tests/\` → clean
- [x] \`ruff format --check\` → clean
- [x] \`pytest\` → **72/72 passing** (7 new + 65 existing; 6 pre-existing tests adjusted for new required \`protected_branch_ids\` field in approval-rule Namespace)
- [x] \`mypy\` → 0 new errors in the new files
- [x] \`trivy fs --severity HIGH,CRITICAL\` → 0
- [x] Code-reviewer agent: 2-round review. First round caught critical bug (approval rule not scoped → would apply project-wide including to main). Fixed via Option A (extend ApprovalRuleOperation). Second round: bug fully resolved, no remaining issues.

## Critical regression test

`TestKahunaSandboxHappyPath::test_approval_rule_post_is_scoped_to_kahuna_protected_branch` parses the approval-rule POST body and asserts `protected_branch_ids == [PROTECTED_BRANCH_ID]`. If scoping regresses, this test fails loudly.