### PR TITLE
chore(settings): go queue-less — disable merge trains and merged-results pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,9 +311,21 @@ gl-settings kahuna-sandbox <target> [--branch-name-regex "<regex>"]
 1. **Push rule** — `branch_name_regex` widened to include `kahuna/*`
 2. **Protected branch** — `kahuna/*` pattern protected (developer push + developer merge)
 3. **Approval rule** — `kahuna-zero-approvals` with `approvals_required=0` (per-branch scope via knob 2)
-4. **Project settings** — `only_allow_merge_if_pipeline_succeeds=true`, `squash_option=default_on`, `merge_pipelines_enabled=true`, `merge_trains_enabled=true`
+4. **Project settings** — `only_allow_merge_if_pipeline_succeeds=true`, `squash_option=default_on`, `merge_pipelines_enabled=false`, `merge_trains_enabled=false`
 
-Merge trains are **enabled**, not disabled: they batch multiple flight MRs into one pipeline run, which is the throughput story KAHUNA needs. Main branch protection is untouched.
+Merge trains and merged-results pipelines are **disabled** by policy. An earlier version of this
+document claimed trains "batch multiple flight MRs into one pipeline run" — **that is false.** GitLab
+runs a pipeline *per MR in the train* and re-runs successors when a predecessor fails; stacked on
+merged-results pipelines, it cost **3 pipelines per MR** (push + merged-results + train) for a
+batching benefit that does not exist.
+
+Wave work never required a train: flights land on the `kahuna/*` integration branch, the wave engine
+reconciles them with `commutativity_verify` and dependency-ordered merges, and `kahuna→main` is a
+single serialized, trust-gated promotion. There is no concurrent-merge-to-main point for a train to
+guard.
+
+The CI gate (`only_allow_merge_if_pipeline_succeeds`) is **not** what was removed — it stays on. Main
+branch protection is untouched.
 
 **Behavior:**
 

--- a/gl_settings/operations/init_project.py
+++ b/gl_settings/operations/init_project.py
@@ -22,7 +22,12 @@ class InitProjectOperation(Operation):
         "only_allow_merge_if_pipeline_succeeds": True,
         "only_allow_merge_if_all_discussions_are_resolved": True,
         "remove_source_branch_after_merge": True,
-        "merge_pipelines_enabled": True,
+        # Trains and merged-results pipelines OFF by policy — see
+        # kahuna_sandbox.SANDBOX_PROJECT_SETTINGS. Both are asserted explicitly:
+        # GitLab requires merged-results pipelines for trains, but relying on that
+        # cascade would let trains silently return if someone re-enables the former.
+        "merge_pipelines_enabled": False,
+        "merge_trains_enabled": False,
         "issue_branch_template": "feature/%{id}-%{title}",
         "forking_access_level": "disabled",
         "pages_access_level": "private",

--- a/gl_settings/operations/kahuna_sandbox.py
+++ b/gl_settings/operations/kahuna_sandbox.py
@@ -13,8 +13,8 @@ Sub-ops applied, in order:
 2. ``protect-branch`` — protect ``kahuna/*`` pattern (prerequisite for 3).
 3. ``approval-rule`` — per-branch rule with ``approvals_required=0`` scoped
    to the protected ``kahuna/*`` pattern.
-4. ``project-setting`` — enable CI-gate, squash-on-merge, and merge trains
-   so flight-MRs batch into a single pipeline run per train.
+4. ``project-setting`` — enable CI-gate and squash-on-merge. Merge trains and
+   merged-results pipelines are deliberately OFF (see ``SANDBOX_PROJECT_SETTINGS``).
 """
 
 from __future__ import annotations
@@ -38,11 +38,22 @@ KAHUNA_BRANCH_PATTERN = "kahuna/*"
 KAHUNA_APPROVAL_RULE_NAME = "kahuna-zero-approvals"
 
 # Sandbox-enabling project settings.
+#
+# Merge trains and merged-results pipelines are OFF by policy. A train does not
+# batch flight-MRs into one pipeline run — GitLab runs a pipeline per MR in the
+# train and re-runs successors when a predecessor fails. With merged-results
+# pipelines on top, that cost 3 pipelines per MR (push + merged-results + train).
+# Wave work never needed either: flights land on the kahuna branch, the engine
+# reconciles them with commutativity_verify + dependency-ordered merges, and
+# kahuna->main is a single serialized trust-gated promotion.
+#
+# The CI gate (only_allow_merge_if_pipeline_succeeds) is NOT what we removed —
+# it stays on. Only the train/merged-results machinery is gone.
 SANDBOX_PROJECT_SETTINGS: dict[str, bool | str] = {
     "only_allow_merge_if_pipeline_succeeds": True,
     "squash_option": "default_on",
-    "merge_pipelines_enabled": True,
-    "merge_trains_enabled": True,
+    "merge_pipelines_enabled": False,
+    "merge_trains_enabled": False,
 }
 
 
@@ -139,7 +150,7 @@ class KahunaSandboxOperation(Operation):
         if _is_error(sub_results[-1]):
             return self._summarize(project_id, project_path, sub_results)
 
-        # 4. project-setting — CI-gate + squash + merge trains
+        # 4. project-setting — CI-gate + squash; trains/merged-results OFF
         sub_results.append(
             self._run_sub(
                 ProjectSettingOperation,

--- a/scripts/init-project.sh
+++ b/scripts/init-project.sh
@@ -44,7 +44,9 @@ declare -A PROJECT_SETTINGS=(
     ["only_allow_merge_if_pipeline_succeeds"]="true"
     ["only_allow_merge_if_all_discussions_are_resolved"]="true"
     ["remove_source_branch_after_merge"]="true"
-    ["merge_pipelines_enabled"]="true"
+    # Queue-less policy: trains and merged-results pipelines OFF.
+    ["merge_pipelines_enabled"]="false"
+    ["merge_trains_enabled"]="false"
     ["issue_branch_template"]="feature/%{id}-%{title}"
 
     # Access controls

--- a/tests/test_kahuna_sandbox.py
+++ b/tests/test_kahuna_sandbox.py
@@ -105,15 +105,20 @@ def _mock_greenfield_project():
         },
     )
 
-    # 4. project-setting: GET current -> PUT changes
+    # 4. project-setting: GET current -> PUT changes.
+    # Current state models the REAL migration case: a project configured by the
+    # pre-queue-less release, i.e. trains and merged-results pipelines ON. This is
+    # what makes the disable path actually execute — if the fixture already said
+    # False, those keys would never appear in a PUT body and deleting them from
+    # SANDBOX_PROJECT_SETTINGS would leave the suite green.
     responses.add(
         responses.GET,
         f"{MOCK_API_URL}/projects/{PROJECT_ID}",
         json={
             "only_allow_merge_if_pipeline_succeeds": False,
             "squash_option": "default_off",
-            "merge_pipelines_enabled": False,
-            "merge_trains_enabled": False,
+            "merge_pipelines_enabled": True,
+            "merge_trains_enabled": True,
         },
     )
     responses.add(
@@ -144,6 +149,36 @@ class TestKahunaSandboxHappyPath:
         assert write_urls[1].endswith(f"/projects/{PROJECT_ID}/protected_branches")
         assert write_urls[2].endswith(f"/projects/{PROJECT_ID}/approval_rules")
         assert write_urls[3].endswith(f"/projects/{PROJECT_ID}")
+
+    @responses.activate
+    def test_project_setting_put_disables_trains_and_keeps_ci_gate(self):
+        """CRITICAL: the project-setting PUT must turn merge trains and
+        merged-results pipelines OFF (queue-less policy) while leaving the CI
+        gate and squash-on-merge ON. Without this assertion, deleting the
+        merge_trains_enabled / merge_pipelines_enabled entries from
+        SANDBOX_PROJECT_SETTINGS would leave the whole suite green.
+        """
+        import json
+
+        _mock_greenfield_project()
+
+        client = GitLabClient(MOCK_GITLAB_URL, "test-token")
+        op = KahunaSandboxOperation(client, make_args())
+        op.apply_to_project(PROJECT_ID, PROJECT_PATH)
+
+        put_calls = [
+            c
+            for c in responses.calls
+            if c.request.method == "PUT" and c.request.url.rstrip("/").endswith(f"/projects/{PROJECT_ID}")
+        ]
+        assert len(put_calls) == 1, [c.request.url for c in responses.calls]
+
+        body = json.loads(put_calls[0].request.body or "{}")
+        assert body["merge_trains_enabled"] is False, body
+        assert body["merge_pipelines_enabled"] is False, body
+        # The CI gate is NOT what we removed — it must survive.
+        assert body["only_allow_merge_if_pipeline_succeeds"] is True, body
+        assert body["squash_option"] == "default_on", body
 
     @responses.activate
     def test_approval_rule_post_is_scoped_to_kahuna_protected_branch(self):
@@ -233,8 +268,8 @@ class TestKahunaSandboxIdempotency:
             json={
                 "only_allow_merge_if_pipeline_succeeds": True,
                 "squash_option": "default_on",
-                "merge_pipelines_enabled": True,
-                "merge_trains_enabled": True,
+                "merge_pipelines_enabled": False,
+                "merge_trains_enabled": False,
             },
         )
 


### PR DESCRIPTION
## Summary

Makes `gl-settings` queue-less: merge trains and merged-results pipelines are now turned **off**, in both the `kahuna-sandbox` composite and the `init-project` defaults. This is the GitLab half of the fleet-wide queue-less migration (the six GitHub repos had their merge-queue rulesets removed alongside this).

The prior justification was **factually wrong**. `README.md` claimed merge trains *"batch multiple flight MRs into one pipeline run, which is the throughput story KAHUNA needs."* They do not — GitLab runs a pipeline **per MR in the train** and re-runs successors when a predecessor fails. Stacked on merged-results pipelines, that cost **3 pipelines per MR** (push + merged-results + train) for a batching benefit that does not exist.

Wave work never needed a train: flights land on the `kahuna/*` integration branch, the engine reconciles them with `commutativity_verify` + dependency-ordered merges, and `kahuna→main` is a single serialized, trust-gated promotion. There is no concurrent-merge-to-main point for a train to guard.

**The CI gate is not what was removed.** `only_allow_merge_if_pipeline_succeeds` and `squash_option=default_on` stay on — and are now pinned by a test so they cannot be dropped by accident.

## Changes

- `gl_settings/operations/kahuna_sandbox.py` — `SANDBOX_PROJECT_SETTINGS`: `merge_pipelines_enabled` and `merge_trains_enabled` → `False`. Docstring and inline comments corrected.
- `gl_settings/operations/init_project.py` — `DEFAULT_PROJECT_SETTINGS` asserts **both** flags off explicitly, rather than leaning on GitLab’s "merged-results is a prerequisite for trains" cascade. Relying on the cascade would let trains silently return if someone re-enabled the former.
- `scripts/init-project.sh` — deprecated but still shipped, and still set `merge_pipelines_enabled="true"`; running it would have re-enabled exactly what this PR removes.
- `README.md` — replaces the false batching claim with the queue-less rationale, and states the correction explicitly so it is not re-derived later.
- `tests/test_kahuna_sandbox.py` — greenfield fixture now models the **real migration case** (a project with trains currently ON), plus a new guard asserting the project-setting PUT body.

## Linked Issues

Closes #31

## Test Plan

Actually run, not hypothetical:

- `pytest tests/` → **73 passed** (was 72; +1 new guard).
- `ruff check` → clean. `ruff format --check` → 25 files already formatted.
- `mypy` → 8 errors, confirmed **pre-existing baseline** (identical count on `main`, verified by stashing).
- **Mutation-tested the new guard:** deleting `merge_trains_enabled` from `SANDBOX_PROJECT_SETTINGS` makes `test_project_setting_put_disables_trains_and_keeps_ci_gate` **FAIL**; restoring it makes it **PASS**. This matters because before this PR *no test pinned these values at all* — the fixture mocked the current state as already-off, so the keys never appeared in any request body and deleting them outright left the suite green.
- trivy: 0 HIGH/CRITICAL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CSEY5TUixZARAmHrjYTYX