### PR TITLE
fix(settings): merged-results pipelines are NOT merge trains — re-enable them

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,21 +311,49 @@ gl-settings kahuna-sandbox <target> [--branch-name-regex "<regex>"]
 1. **Push rule** — `branch_name_regex` widened to include `kahuna/*`
 2. **Protected branch** — `kahuna/*` pattern protected (developer push + developer merge)
 3. **Approval rule** — `kahuna-zero-approvals` with `approvals_required=0` (per-branch scope via knob 2)
-4. **Project settings** — `only_allow_merge_if_pipeline_succeeds=true`, `squash_option=default_on`, `merge_pipelines_enabled=false`, `merge_trains_enabled=false`
+4. **Project settings** — `only_allow_merge_if_pipeline_succeeds=true`, `squash_option=default_on`, `merge_pipelines_enabled=true`, `merge_trains_enabled=false`
 
-Merge trains and merged-results pipelines are **disabled** by policy. An earlier version of this
-document claimed trains "batch multiple flight MRs into one pipeline run" — **that is false.** GitLab
-runs a pipeline *per MR in the train* and re-runs successors when a predecessor fails; stacked on
-merged-results pipelines, it cost **3 pipelines per MR** (push + merged-results + train) for a
-batching benefit that does not exist.
+**Merge trains are disabled. Merged-results pipelines are enabled. These are different features —
+do not conflate them.** (We did, once, and it silently blinded the wave gate. See #33.)
 
-Wave work never required a train: flights land on the `kahuna/*` integration branch, the wave engine
-reconciles them with `commutativity_verify` and dependency-ordered merges, and `kahuna→main` is a
-single serialized, trust-gated promotion. There is no concurrent-merge-to-main point for a train to
-guard.
+**Merge trains — OFF.** An earlier version of this document claimed trains "batch multiple flight MRs
+into one pipeline run." **That is false.** GitLab runs a pipeline *per MR in the train* and re-runs
+successors when a predecessor fails. Wave work never required one anyway: flights land on the
+`kahuna/*` integration branch, the wave engine reconciles them with `commutativity_verify` and
+dependency-ordered merges, and `kahuna→main` is a single serialized, trust-gated promotion. Nothing
+merges to the target concurrently, so there is nothing for a train to guard.
 
-The CI gate (`only_allow_merge_if_pipeline_succeeds`) is **not** what was removed — it stays on. Main
-branch protection is untouched.
+**Merged-results pipelines — ON.** These run CI against the *result of merging source into target*
+rather than against the source branch HEAD. A merge train happens to require them, but they stand on
+their own — and the KAHUNA trust gate **depends** on them: its CI signal validates the **merge-result**
+pipeline, never the branch HEAD (`mcp-server-sdlc#452`). Disable them and the gate keeps passing while
+silently grading the wrong commit. No error, just a blind gate.
+
+Dropping the train alone already takes GitLab from **3 pipelines per MR to 2** (push + merged-results).
+The third was the train. Going to 1 buys one pipeline and pays for it with a gate that no longer checks
+what it claims to check.
+
+The CI gate (`only_allow_merge_if_pipeline_succeeds`) stays on. Main branch protection is untouched.
+
+#### ⚠️ Prerequisite — the setting alone is not enough
+
+`merge_pipelines_enabled=true` is **necessary but not sufficient**. GitLab only produces a
+merged-results pipeline if the project's `.gitlab-ci.yml` also admits **merge-request pipelines** —
+i.e. a `workflow:rules` or job `rules` entry matching `$CI_PIPELINE_SOURCE == "merge_request_event"`.
+
+If the CI config only defines branch pipelines, then even with this knob set:
+
+- the MR gets a plain **branch** pipeline,
+- `only_allow_merge_if_pipeline_succeeds` gates on *that*,
+- the wave gate goes back to grading the **branch HEAD**,
+- and **every setting here audits clean.** `gl-settings kahuna-sandbox` reports `applied`.
+
+That is the same blindness this section exists to prevent, relocated one layer down. Check the
+project's `.gitlab-ci.yml` before trusting the gate.
+
+Note also that GitLab **silently falls back** to a standard MR pipeline when the source and target
+branches have conflicting changes — so a merge-result pipeline is not guaranteed even on a correctly
+configured project.
 
 **Behavior:**
 

--- a/gl_settings/operations/init_project.py
+++ b/gl_settings/operations/init_project.py
@@ -22,11 +22,13 @@ class InitProjectOperation(Operation):
         "only_allow_merge_if_pipeline_succeeds": True,
         "only_allow_merge_if_all_discussions_are_resolved": True,
         "remove_source_branch_after_merge": True,
-        # Trains and merged-results pipelines OFF by policy — see
-        # kahuna_sandbox.SANDBOX_PROJECT_SETTINGS. Both are asserted explicitly:
-        # GitLab requires merged-results pipelines for trains, but relying on that
-        # cascade would let trains silently return if someone re-enables the former.
-        "merge_pipelines_enabled": False,
+        # Trains OFF, merged-results ON. These are DIFFERENT features — see the
+        # comment on kahuna_sandbox.SANDBOX_PROJECT_SETTINGS. Merged-results
+        # pipelines produce the merge-result pipeline the wave gate validates
+        # (mcp-server-sdlc#452); disabling them blinds the gate silently.
+        # Both asserted explicitly so neither can drift via GitLab's
+        # trains-require-merged-results cascade.
+        "merge_pipelines_enabled": True,
         "merge_trains_enabled": False,
         "issue_branch_template": "feature/%{id}-%{title}",
         "forking_access_level": "disabled",

--- a/gl_settings/operations/kahuna_sandbox.py
+++ b/gl_settings/operations/kahuna_sandbox.py
@@ -13,8 +13,19 @@ Sub-ops applied, in order:
 2. ``protect-branch`` — protect ``kahuna/*`` pattern (prerequisite for 3).
 3. ``approval-rule`` — per-branch rule with ``approvals_required=0`` scoped
    to the protected ``kahuna/*`` pattern.
-4. ``project-setting`` — enable CI-gate and squash-on-merge. Merge trains and
-   merged-results pipelines are deliberately OFF (see ``SANDBOX_PROJECT_SETTINGS``).
+4. ``project-setting`` — enable CI-gate and squash-on-merge. Merge **trains** are
+   OFF; merged-results **pipelines** are ON. Those are different features and move
+   in opposite directions — see ``SANDBOX_PROJECT_SETTINGS``.
+
+.. warning::
+
+   ``merge_pipelines_enabled=True`` is necessary but **not sufficient** to get a
+   merge-result pipeline. GitLab also requires the project's ``.gitlab-ci.yml`` to
+   admit merge-request pipelines (a ``workflow``/job rule matching
+   ``$CI_PIPELINE_SOURCE == "merge_request_event"``). Without that, the MR only ever
+   gets a *branch* pipeline, and the KAHUNA trust gate is grading the branch HEAD —
+   with every knob here auditing clean. GitLab also silently falls back to a standard
+   MR pipeline when the branches have conflicting changes.
 """
 
 from __future__ import annotations
@@ -39,20 +50,37 @@ KAHUNA_APPROVAL_RULE_NAME = "kahuna-zero-approvals"
 
 # Sandbox-enabling project settings.
 #
-# Merge trains and merged-results pipelines are OFF by policy. A train does not
-# batch flight-MRs into one pipeline run — GitLab runs a pipeline per MR in the
-# train and re-runs successors when a predecessor fails. With merged-results
-# pipelines on top, that cost 3 pipelines per MR (push + merged-results + train).
-# Wave work never needed either: flights land on the kahuna branch, the engine
-# reconciles them with commutativity_verify + dependency-ordered merges, and
-# kahuna->main is a single serialized trust-gated promotion.
+# THESE TWO ARE DIFFERENT FEATURES. Do not conflate them (we did once, in #31,
+# and it silently blinded the wave gate — see #33).
 #
-# The CI gate (only_allow_merge_if_pipeline_succeeds) is NOT what we removed —
-# it stays on. Only the train/merged-results machinery is gone.
+#   merge_trains_enabled     — OFF. A train serializes MRs and runs a pipeline
+#                              PER MR IN THE TRAIN, re-running successors when a
+#                              predecessor fails. It does NOT batch them into one
+#                              run. Wave work never needed it: flights land on the
+#                              kahuna branch, the engine reconciles them with
+#                              commutativity_verify + dependency-ordered merges,
+#                              and kahuna->main is a single serialized, trust-gated
+#                              promotion. Nothing merges to the target concurrently.
+#
+#   merge_pipelines_enabled  — ON. "Merged results pipelines" run CI against the
+#                              RESULT OF MERGING source into target, rather than
+#                              against the source branch HEAD. A merge train happens
+#                              to require this, but it stands on its own — and the
+#                              KAHUNA trust gate DEPENDS on it: the gate's CI signal
+#                              validates the MERGE-RESULT pipeline, never the branch
+#                              HEAD (mcp-server-sdlc#452). Turn this off and the gate
+#                              silently grades the wrong thing — no error, it just
+#                              stops checking what it claims to check.
+#
+# Dropping the train alone already takes GitLab from 3 pipelines per MR to 2
+# (push + merged-results). The third was the train. Going to 1 buys one pipeline
+# and pays for it with a blind gate.
+#
+# The CI gate (only_allow_merge_if_pipeline_succeeds) stays on regardless.
 SANDBOX_PROJECT_SETTINGS: dict[str, bool | str] = {
     "only_allow_merge_if_pipeline_succeeds": True,
     "squash_option": "default_on",
-    "merge_pipelines_enabled": False,
+    "merge_pipelines_enabled": True,
     "merge_trains_enabled": False,
 }
 
@@ -150,7 +178,7 @@ class KahunaSandboxOperation(Operation):
         if _is_error(sub_results[-1]):
             return self._summarize(project_id, project_path, sub_results)
 
-        # 4. project-setting — CI-gate + squash; trains/merged-results OFF
+        # 4. project-setting — CI-gate + squash; trains OFF, merged-results ON
         sub_results.append(
             self._run_sub(
                 ProjectSettingOperation,

--- a/scripts/init-project.sh
+++ b/scripts/init-project.sh
@@ -44,8 +44,9 @@ declare -A PROJECT_SETTINGS=(
     ["only_allow_merge_if_pipeline_succeeds"]="true"
     ["only_allow_merge_if_all_discussions_are_resolved"]="true"
     ["remove_source_branch_after_merge"]="true"
-    # Queue-less policy: trains and merged-results pipelines OFF.
-    ["merge_pipelines_enabled"]="false"
+    # Trains OFF. Merged-results pipelines ON — they are a DIFFERENT feature, and the
+    # wave gate validates the merge-result pipeline they produce (mcp-server-sdlc#452).
+    ["merge_pipelines_enabled"]="true"
     ["merge_trains_enabled"]="false"
     ["issue_branch_template"]="feature/%{id}-%{title}"
 

--- a/tests/test_kahuna_sandbox.py
+++ b/tests/test_kahuna_sandbox.py
@@ -106,18 +106,20 @@ def _mock_greenfield_project():
     )
 
     # 4. project-setting: GET current -> PUT changes.
-    # Current state models the REAL migration case: a project configured by the
-    # pre-queue-less release, i.e. trains and merged-results pipelines ON. This is
-    # what makes the disable path actually execute — if the fixture already said
-    # False, those keys would never appear in a PUT body and deleting them from
-    # SANDBOX_PROJECT_SETTINGS would leave the suite green.
+    # Current state models the REAL migration case, and it is deliberately WRONG in
+    # BOTH directions so the PUT body must carry both keys:
+    #   trains ON            -> must be turned OFF
+    #   merged-results OFF   -> must be turned ON   (the #33 regression: #31 wrongly
+    #                           disabled these, silently blinding the wave gate)
+    # If a fixture value already matched the desired value, that key would never
+    # appear in the PUT body and the guard below would assert nothing.
     responses.add(
         responses.GET,
         f"{MOCK_API_URL}/projects/{PROJECT_ID}",
         json={
             "only_allow_merge_if_pipeline_succeeds": False,
             "squash_option": "default_off",
-            "merge_pipelines_enabled": True,
+            "merge_pipelines_enabled": False,
             "merge_trains_enabled": True,
         },
     )
@@ -151,12 +153,20 @@ class TestKahunaSandboxHappyPath:
         assert write_urls[3].endswith(f"/projects/{PROJECT_ID}")
 
     @responses.activate
-    def test_project_setting_put_disables_trains_and_keeps_ci_gate(self):
-        """CRITICAL: the project-setting PUT must turn merge trains and
-        merged-results pipelines OFF (queue-less policy) while leaving the CI
-        gate and squash-on-merge ON. Without this assertion, deleting the
-        merge_trains_enabled / merge_pipelines_enabled entries from
-        SANDBOX_PROJECT_SETTINGS would leave the whole suite green.
+    def test_project_setting_put_disables_trains_but_keeps_merged_results(self):
+        """CRITICAL: merge TRAINS and MERGED-RESULTS pipelines are different
+        features and must move in OPPOSITE directions. This test exists because
+        #31 conflated them, turned both off, and silently blinded the wave gate
+        (#33).
+
+          merge_trains_enabled    -> False   (a train serializes MRs; we don't need one)
+          merge_pipelines_enabled -> True    (produces the MERGE-RESULT pipeline the
+                                              KAHUNA trust gate validates instead of the
+                                              branch HEAD -- mcp-server-sdlc#452. Turn it
+                                              off and the gate keeps passing while grading
+                                              the wrong commit. No error. Just blind.)
+
+        The CI gate and squash-on-merge must survive untouched.
         """
         import json
 
@@ -175,7 +185,8 @@ class TestKahunaSandboxHappyPath:
 
         body = json.loads(put_calls[0].request.body or "{}")
         assert body["merge_trains_enabled"] is False, body
-        assert body["merge_pipelines_enabled"] is False, body
+        # NOT False. These are different features -- see the docstring.
+        assert body["merge_pipelines_enabled"] is True, body
         # The CI gate is NOT what we removed — it must survive.
         assert body["only_allow_merge_if_pipeline_succeeds"] is True, body
         assert body["squash_option"] == "default_on", body
@@ -268,7 +279,7 @@ class TestKahunaSandboxIdempotency:
             json={
                 "only_allow_merge_if_pipeline_succeeds": True,
                 "squash_option": "default_on",
-                "merge_pipelines_enabled": False,
+                "merge_pipelines_enabled": True,
                 "merge_trains_enabled": False,
             },
         )


### PR DESCRIPTION
## Summary

**Fixes a regression I introduced in #32.** That PR disabled *both* `merge_trains_enabled` and `merge_pipelines_enabled`, treating them as one feature. They are not.

| Setting | State | What it is |
|---|---|---|
| `merge_trains_enabled` | **OFF** (correct) | Serializes MRs into a train, running a pipeline **per MR in the train** and re-running successors on a predecessor failure. It does not batch. We never needed one. |
| `merge_pipelines_enabled` | **ON** (restored) | "Merged results pipelines" — runs CI against the **result of merging source into target**, not the source branch HEAD. Trains *require* it, but it stands on its own. |

**Why the conflation matters.** The KAHUNA trust gate’s CI signal deliberately validates the **merge-result** pipeline and never the branch HEAD — that distinction is the entire point of `mcp-server-sdlc#452`. On GitLab, the merge-result pipeline **is** the merged-results pipeline. Turn it off and an MR only ever produces a branch pipeline, so the gate silently starts grading the wrong commit. **No error is raised.** The wave still promotes; it just validated something other than what it claims to validate. That is worse than a broken gate, because it is a *believed* gate.

Cost was never the reason to remove it: dropping the train alone already takes GitLab from **3 pipelines per MR → 2** (push + merged-results). The third was the train. Going to 1 buys one pipeline and pays for it with a blind gate.

## Changes

- `kahuna_sandbox.py` — `merge_pipelines_enabled: True`; trains stay `False`. The block comment now spells out that these are **different features moving in opposite directions**, so they cannot be re-conflated.
- **The module docstring and step-4 comment still asserted the bug** ("trains and merged-results pipelines are deliberately OFF") while citing the dict that now says the opposite. Corrected — a stale docstring in *this* file is a live re-regression vector.
- `init_project.py`, `scripts/init-project.sh` — same pair.
- `README.md` — states the distinction, cites sdlc#452, and adds the prerequisite below.
- `tests/test_kahuna_sandbox.py` — the guard now pins **both** values. The greenfield fixture is deliberately wrong in **both directions** (trains ON, merged-results OFF) so both keys must appear in the PUT body; had either already matched the desired value, `project_setting` would have dropped it from the request and the assertion would have checked nothing.

## The fix is necessary but NOT sufficient (review finding — documented, follow-ups filed)

`merge_pipelines_enabled=true` alone does **not** guarantee a merge-result pipeline. GitLab also requires the project’s `.gitlab-ci.yml` to admit merge-request pipelines (`$CI_PIPELINE_SOURCE == "merge_request_event"`), and it **silently falls back** to a branch pipeline when the branches have conflicting changes.

So the gate can *still* be blind with every knob here set correctly and `gl-settings kahuna-sandbox` reporting `applied`. Same failure, one layer down. Documented in the README; filed:

- **#34** — have the composite inspect `.gitlab-ci.yml` and warn when it admits no MR pipelines.
- **[mcp-server-sdlc#476](https://github.com/Wave-Engineering/mcp-server-sdlc/issues/476)** (`severity::critical`) — the real fix: `ci_wait_run` must **assert** that the pipeline it graded *is* a merge-result pipeline, rather than assuming it. Today a green **branch** pipeline can satisfy the wave gate.

## Linked Issues

Closes #33

## Test Plan

Actually run:

- `pytest tests/` → **73 passed**
- `ruff check` → clean; `ruff format --check` → 25 files already formatted
- **Mutation-tested the guard:** re-conflating the features (setting `merge_pipelines_enabled: False`) turns **2 tests red** — the PUT-body guard and the idempotency test. Restoring makes them pass.
- Verified the fixture actually forces both keys into the PUT body (the `project_setting` diff logic drops unchanged keys, which is how a careless fixture would make this assert nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013CSEY5TUixZARAmHrjYTYX